### PR TITLE
Reworked permission module to use JWT token

### DIFF
--- a/management_layer/api/schemas.py
+++ b/management_layer/api/schemas.py
@@ -336,7 +336,7 @@ client = json.loads("""
             "type": "string"
         },
         "reuse_consent": {
-            "description": "If enabled, the Server will save the user consent given to a specific client, so that user wont be prompted for the same authorization multiple times.",
+            "description": "If enabled, the Server will save the user consent given to a specific client, so that user will not be prompted for the same authorization multiple times.",
             "type": "boolean"
         },
         "terms_url": {

--- a/management_layer/api/stubs.py
+++ b/management_layer/api/stubs.py
@@ -1016,7 +1016,7 @@ class MockedStubClass(AbstractStubClass):
                 "type": "string"
             },
             "reuse_consent": {
-                "description": "If enabled, the Server will save the user consent given to a specific client, so that user wont be prompted for the same authorization multiple times.",
+                "description": "If enabled, the Server will save the user consent given to a specific client, so that user will not be prompted for the same authorization multiple times.",
                 "type": "boolean"
             },
             "terms_url": {

--- a/management_layer/api/views.py
+++ b/management_layer/api/views.py
@@ -290,7 +290,7 @@ class Clients(View):
                 "type": "string"
             },
             "reuse_consent": {
-                "description": "If enabled, the Server will save the user consent given to a specific client, so that user wont be prompted for the same authorization multiple times.",
+                "description": "If enabled, the Server will save the user consent given to a specific client, so that user will not be prompted for the same authorization multiple times.",
                 "type": "boolean"
             },
             "terms_url": {
@@ -3972,7 +3972,7 @@ class __SWAGGER_SPEC__(View):
                     "type": "string"
                 },
                 "reuse_consent": {
-                    "description": "If enabled, the Server will save the user consent given to a specific client, so that user wont be prompted for the same authorization multiple times.",
+                    "description": "If enabled, the Server will save the user consent given to a specific client, so that user will not be prompted for the same authorization multiple times.",
                     "type": "boolean"
                 },
                 "terms_url": {

--- a/management_layer/mappings.py
+++ b/management_layer/mappings.py
@@ -24,6 +24,7 @@ PERMISSION_NAME_TO_ID_MAP = {}
 RESOURCE_URN_TO_ID_MAP = {}
 ROLE_LABEL_TO_ID_MAP = {}
 SITE_NAME_TO_ID_MAP = {}
+SITE_CLIENT_ID_TO_ID_MAP = {}
 
 # The API client used to load the data
 API = AccessControlApi()
@@ -95,6 +96,10 @@ def refresh_sites():
     global SITES
     global SITE_NAME_TO_ID_MAP
     SITES, SITE_NAME_TO_ID_MAP = _load(API.site_list, "name")
+    global SITE_CLIENT_ID_TO_ID_MAP
+    SITE_CLIENT_ID_TO_ID_MAP = {
+        detail["client_id"]: id_ for id_, detail in SITES.items()
+    }
 
 
 def refresh_all():

--- a/management_layer/middleware.py
+++ b/management_layer/middleware.py
@@ -51,14 +51,13 @@ async def auth_middleware(app, handler):
                 return json_response({"message": "Exception: {} {}".format(type(e), str(e))},
                                      status=INVALID_TOKEN_STATUS)
 
-            request["user_id"] = payload["sub"]
-            request["client_id"] = payload["aud"]
-            request["token"] = payload
             LOGGER.debug("Token payload: {}".format(payload))
+            request["token"] = payload
         elif settings.INSECURE:
-            request["user_id"] = "40b724d6-1d33-11e8-afe3-6f15f0cf1da3"
-            request["client_id"] = "management_layer_workaround"
-            request["token"] = {}
+            request["token"] = {
+                "sub": "40b724d6-1d33-11e8-afe3-6f15f0cf1da3",
+                "aud": "management_layer_workaround"
+            }
             LOGGER.debug("Faking credentials because INSECURE is true.")
         else:
             return json_response({"message": "An authentication token is required"},

--- a/management_layer/permission/__init__.py
+++ b/management_layer/permission/__init__.py
@@ -3,19 +3,19 @@ The permission module exposes a decorator that can be used to protect
 function calls by specifying the permissions required to execute the function.
 """
 import typing
+import uuid
 from functools import wraps
-from uuid import UUID
 
 from management_layer.permission.utils import Operator, ResourcePermissions, \
     user_has_permissions, Forbidden
+from management_layer.mappings import SITE_CLIENT_ID_TO_ID_MAP
 
 
 def require_permissions(
-        operator: Operator,
-        resource_permissions: ResourcePermissions,
-        nocache: bool = False,
-        user_field: typing.Union[int, str] = 0,
-        site_field: typing.Union[int, str] = 1
+    operator: Operator,
+    resource_permissions: ResourcePermissions,
+    nocache: bool = False,
+    request_field: typing.Union[int, str] = 0
 ) -> typing.Callable:
     """
     This function is used as a decorator to protect functions by specifying
@@ -24,7 +24,7 @@ def require_permissions(
     @require_permissions(all, [("urn:ge:test:foo", "write")])
     @require_permissions(any, [("urn:ge:test:foo", "read"),
                                ("urn:ge:test:bar", "read"])
-    def doSomething(user, site, arg1, arg2):
+    def doSomething(request, arg1, arg2):
         pass
     ```
     As can be seen from the example above, the decorator can be stacked.
@@ -35,43 +35,38 @@ def require_permissions(
     @require_permissions(all, [("urn:ge:test:foo", "write")])
     @require_permissions(all, [("urn:ge:test:bar", "write")])
     @require_permissions(all, [("urn:ge:test:baz", "write")])
-    def badExample(user, site, arg1, arg2):
+    def badExample(request, arg1, arg2):
         pass
 
     # Logically equivalent to the decorators of example above and more efficient
     @require_permissions(all, [("urn:ge:test:foo", "write"),
                                ("urn:ge:test:bar", "write"),
                                ("urn:ge:test:baz", "write")])
-    def goodExample(user, site, arg1, arg2):
+    def goodExample(request, arg1, arg2):
         pass
     ```
     This function requires the the user who made the request as well as the
     site from which the request originated in order to look up roles
-    associated with the user. The user and site UUID values is picked from
-    the values passed to the decorated function. By default we use the first
-    argument as the user value and the second as the site. This can be
-    changed in the decorator, e.g.
+    associated with the user. The user and site UUID values are read from
+    the request field passed to the decorated function. By default we use the first
+    argument as the request field. This can be changed in the decorator, e.g.
     ```
     @require_permissions(all, [("urn:ge:test:baz", "write")],
-                         site_field=2, user_field=3)
-    def example1(arg1, arg2, site, user):
+                         request_field=2)
+    def example1(arg1, arg2, request):
         pass
 
     @require_permissions(all, [("urn:ge:test:baz", "write")],
-                         site_field=0, user_field="user")  # "user" in kwargs
-    def example2(site, **kwargs):
+                         request_field="request")  # "request" in kwargs
+    def example2(arg1, **kwargs):
         pass
     ```
 
     :param operator: any or all
     :param resource_permissions: The resource permissions required
     :param nocache: Bypass the cache if True
-    :param user_field: An integer or string identifying either the positional
-        argument or the name of the keyword argument identifying the user
-        making the request.
-    :param site_field: An integer or string identifying either the positional
-        argument or the name of the keyword argument identifying the site from
-        which the request is made.
+    :param request_field: An integer or string identifying either the positional
+        argument or the name of the keyword argument identifying the request parameter.
     :raises: Forbidden if the user does not have the required permissions.
     """
     if operator not in [any, all]:
@@ -86,34 +81,30 @@ def require_permissions(
             :param kwargs: A dictionary of keyword arguments
             :return: Whatever the wrapped function
             """
-            # Extract the user UUID from the function arguments
-            user_field_type = type(user_field)
-            if user_field_type is int:
-                user = args[user_field]
-            elif user_field_type is str:
-                user = kwargs[user_field]
+            # Extract the request from the function arguments
+            request_field_type = type(request_field)
+            if request_field_type is int:
+                request = args[request_field]
+            elif request_field_type is str:
+                request = kwargs[request_field]
             else:
-                raise RuntimeError("Invalid value for user_field")
+                raise RuntimeError("Invalid value for request_field")
 
-            # Validate the UUID
-            if not isinstance(user, UUID):
-                raise RuntimeError("User is expected to be a UUID")
+            # The request contains the JWT token payload from which we get
+            # * the user id from the "sub" (subscriber) field
+            # * the client id from the "aud" (audience) field
 
-            # Extract the site UUID from the function arguments
-            site_field_type = type(site_field)
-            if site_field_type is int:
-                site = args[site_field]
-            elif site_field_type is str:
-                site = kwargs[site_field]
-            else:
-                raise RuntimeError("Invalid value for site_field")
-
-            # Validate the UUID
-            if not isinstance(site, UUID):
-                raise RuntimeError("Site is expected to be a UUID")
+            # Extract the user's UUID from the request
+            user = uuid.UUID(request["token"]["sub"])
+            # Extract the client id from the request
+            client_id = request["token"]["aud"]
+            try:
+                site_id = SITE_CLIENT_ID_TO_ID_MAP[client_id]
+            except KeyError:
+                raise Forbidden("No site linked to the client ID")
 
             if user_has_permissions(user, operator, resource_permissions,
-                                    site=site, nocache=nocache):
+                                    site=site_id, nocache=nocache):
                 return f(*args, **kwargs)
 
             # If the necessary permissions are not available, we always raise

--- a/management_layer/permission/test_utils.py
+++ b/management_layer/permission/test_utils.py
@@ -145,10 +145,6 @@ class TestRequirePermissionsDecorator(TestCase):
 
     @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
                 TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
-    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
-                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
-    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
-                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.ROLE_LABEL_TO_ID_MAP",
                 TEST_ROLE_LABEL_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.PERMISSION_NAME_TO_ID_MAP",

--- a/management_layer/permission/test_utils.py
+++ b/management_layer/permission/test_utils.py
@@ -13,6 +13,10 @@ from management_layer.permission import utils, require_permissions
 TEST_ROLE_LABEL_TO_ID_MAP = {"role{}".format(i): i for i in range(1, 11)}
 TEST_PERMISSION_NAME_TO_ID_MAP = {"permission{}".format(i): i for i in range(1, 11)}
 TEST_RESOURCE_URN_TO_ID_MAP = {"urn:resource{}".format(i): i for i in range(1, 11)}
+TEST_SITES = {1: {"client_id": "test_client"}}
+TEST_SITE_CLIENT_ID_TO_ID_MAP = {
+    detail["client_id"]: id_ for id_, detail in TEST_SITES.items()
+}
 
 
 class TestRequirePermissionsDecorator(TestCase):
@@ -20,6 +24,16 @@ class TestRequirePermissionsDecorator(TestCase):
     These tests exercise the functionality provided by the @require_permissions
     decorator.
     """
+    def setUp(self):
+        self.user = uuid1()
+        self.site_id = 1
+        self.client_id = TEST_SITES[self.site_id]["client_id"]
+        self.dummy_request = {
+            "token": {
+                "sub": self.user.hex,
+                "aud": self.client_id
+            }
+        }
 
     def test_name_and_docstring(self):
         """
@@ -27,13 +41,15 @@ class TestRequirePermissionsDecorator(TestCase):
         the same when the decorator is implemented properly.
         """
         @require_permissions(all, [("urn:ge:test:foo", "read")])
-        def simple(_user, _site, **_kwargs):
+        def simple(_request, **_kwargs):
             """This docstring is checked."""
             pass
 
         self.assertEqual(simple.__name__, "simple")
         self.assertEqual(simple.__doc__, "This docstring is checked.")
 
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch("management_layer.permission.utils.get_user_roles_for_site")
     def test_empty_resource_permissions_lists(self, mocked_function):
         """
@@ -46,46 +62,45 @@ class TestRequirePermissionsDecorator(TestCase):
         # require_permissions(all, []) always succeeds, regardless of which
         # roles the user has.
         @require_permissions(all, [])
-        def empty_all(_user, _site):
+        def empty_all(_request):
             return True
 
         # require_permissions(any, []) always fails, regardless of which roles
         # the user has.
         @require_permissions(any, [])
-        def empty_any(_user, _site):
+        def empty_any(_request):
             raise RuntimeError("This should never get executed")
 
         mocked_function.return_value = ["some_role"]
-        valid_uuid = uuid1()
 
         # Always gets allowed, regardless of the user's roles
-        self.assertTrue(empty_all(valid_uuid, valid_uuid))
+        self.assertTrue(empty_all(self.dummy_request))
 
         # Never gets allowed, regardless of the user's roles
         with self.assertRaises(utils.Forbidden):
-            empty_any(valid_uuid, valid_uuid)
+            empty_any(self.dummy_request)
 
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch("management_layer.permission.utils.get_user_roles_for_site")
     def test_positional_args(self, mocked_function):
         """
-        Check that positional argument lookups of the user and site
-        information works.
+        Check that positional argument lookups of the request works.
         We mock a response for the get_user_roles_for_site() function in
         order to check that it was called with the appropriate values.
         """
-        @require_permissions(all, [], user_field=2, site_field=1)
-        def positional_args(_arg1, _site, _user):
+        @require_permissions(all, [], request_field=1)
+        def positional_args(_arg1, _request):
             return True
 
-        user = uuid1()
-        site = uuid1()
-
         # Call the test function...
-        positional_args("some_value", site, user)
+        positional_args("some_value", self.dummy_request)
         # ...and verify that the mocked function was called with the right
         # arguments.
-        mocked_function.assert_called_with(user, site, False)
+        mocked_function.assert_called_with(self.user, self.site_id, False)
 
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch("management_layer.permission.utils.get_user_roles_for_site")
     def test_keyword_args(self, mocked_function):
         """
@@ -93,40 +108,15 @@ class TestRequirePermissionsDecorator(TestCase):
         We mock a response for the get_user_roles_for_site() function in
         order to check that it was called with the appropriate values.
         """
-        @require_permissions(all, [], user_field="user_id", site_field="site_id")
+        @require_permissions(all, [], request_field="i_am_a_request")
         def keyword_args(**kwargs):
             return True
 
-        user = uuid1()
-        site = uuid1()
-
         # Call the test function...
-        keyword_args(site_id=site, arg=123, user_id=user)
+        keyword_args(arg=123, i_am_a_request=self.dummy_request)
         # ...and verify that the mocked function was called with the right
         # arguments.
-        mocked_function.assert_called_with(user, site, False)
-
-    @patch("management_layer.permission.utils.get_user_roles_for_site")
-    def test_mixed_args_nocache(self, mocked_function):
-        """
-        Check that a mix of positional and keyword-based lookups of user and
-        site information works.
-        We mock a response for the get_user_roles_for_site() function in
-        order to check that it was called with the appropriate values.
-        """
-        @require_permissions(all, [], user_field="user_id", site_field=1,
-                             nocache=True)
-        def mixed_args(_arg1, _site, **_kwargs):
-            return True
-
-        user = uuid1()
-        site = uuid1()
-
-        # Call the test function...
-        mixed_args(123, site, user_id=user)
-        # ...and verify that the mocked function was called with the right
-        # arguments.
-        mocked_function.assert_called_with(user, site, True)
+        mocked_function.assert_called_with(self.user, self.site_id, False)
 
     @patch("management_layer.permission.utils.get_user_roles_for_site")
     def test_stacked_decorators(self, mocked_function):
@@ -137,23 +127,28 @@ class TestRequirePermissionsDecorator(TestCase):
         """
         @require_permissions(all, [])
         @require_permissions(any, [])
-        def stack(_user, _site):
+        def stack(_request):
             raise RuntimeError("This should never get executed")
 
         @require_permissions(any, [])
         @require_permissions(all, [])
-        def reverse_stack(_user, _site):
+        def reverse_stack(_request):
             raise RuntimeError("This should never get executed")
 
         mocked_function.return_value = ["some_role"]
-        valid_uuid = uuid1()
 
         with self.assertRaises(utils.Forbidden):
-            stack(valid_uuid, valid_uuid)
+            stack(self.dummy_request)
 
         with self.assertRaises(utils.Forbidden):
-            reverse_stack(valid_uuid, valid_uuid)
+            reverse_stack(self.dummy_request)
 
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.ROLE_LABEL_TO_ID_MAP",
                 TEST_ROLE_LABEL_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.PERMISSION_NAME_TO_ID_MAP",
@@ -180,45 +175,45 @@ class TestRequirePermissionsDecorator(TestCase):
             dummy_get_role_resource_permissions
 
         @require_permissions(all, [("urn:resource1", "permission1")])
-        def single_requirement(_user, _site):
+        def single_requirement(_request):
             return True
 
         # The values for the user and site is not important since this test
         # mocks the roles returned.
-        user = uuid1()
-        site = uuid1()
 
         # If the user has no roles, then access is denied.
         mocked_get_user_roles_for_site.return_value = []
         with self.assertRaises(utils.Forbidden):
-            single_requirement(user, site)
+            single_requirement(self.dummy_request)
 
         # If the user has a role without the necessary permission,
         # then access is denied.
         mocked_get_user_roles_for_site.return_value = ["role2"]
         with self.assertRaises(utils.Forbidden):
-            single_requirement(user, site)
+            single_requirement(self.dummy_request)
 
         # If the user has a role with the necessary permission,
         # then access is allowed.
         mocked_get_user_roles_for_site.return_value = ["role1"]
-        self.assertTrue(single_requirement(user, site))
+        self.assertTrue(single_requirement(self.dummy_request))
 
         @require_permissions(all, [("urn:resource1", "permission1"),
                                    ("urn:resource2", "permission2")])
-        def multiple_requirements(_user, _site):
+        def multiple_requirements(_request):
             return True
 
         # If the user has only one of the permissions, then access is
         # denied.
         mocked_get_user_roles_for_site.return_value = ["role1"]
         with self.assertRaises(utils.Forbidden):
-            multiple_requirements(user, site)
+            multiple_requirements(self.dummy_request)
 
         # If the user has all the permissions, then access is allowed.
         mocked_get_user_roles_for_site.return_value = ["role1", "role2"]
-        self.assertTrue(multiple_requirements(user, site))
+        self.assertTrue(multiple_requirements(self.dummy_request))
 
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.ROLE_LABEL_TO_ID_MAP",
                 TEST_ROLE_LABEL_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.PERMISSION_NAME_TO_ID_MAP",
@@ -245,52 +240,52 @@ class TestRequirePermissionsDecorator(TestCase):
             dummy_get_role_resource_permissions
 
         @require_permissions(any, [("urn:resource1", "permission1")])
-        def single_requirement(_user, _site):
+        def single_requirement(_request):
             return True
 
         # The values for the user and site is not important since this test
         # mocks the roles returned.
-        user = uuid1()
-        site = uuid1()
 
         # If the user has no roles, then access is denied.
         mocked_get_user_roles_for_site.return_value = []
         with self.assertRaises(utils.Forbidden):
-            single_requirement(user, site)
+            single_requirement(self.dummy_request)
 
         # If the user has a role without the necessary permission,
         # then access is denied.
         mocked_get_user_roles_for_site.return_value = ["role2"]
         with self.assertRaises(utils.Forbidden):
-            single_requirement(user, site)
+            single_requirement(self.dummy_request)
 
         # If the user has a role with the necessary permission,
         # then access is allowed.
         mocked_get_user_roles_for_site.return_value = ["role1"]
-        self.assertTrue(single_requirement(user, site))
+        self.assertTrue(single_requirement(self.dummy_request))
 
         @require_permissions(any, [("urn:resource1", "permission1"),
                                    ("urn:resource2", "permission2")])
-        def multiple_requirements(_user, _site):
+        def multiple_requirements(_request):
             return True
 
         # If the user has any one of the permissions, then access is
         # allowed.
         mocked_get_user_roles_for_site.return_value = ["role1"]
-        self.assertTrue(multiple_requirements(user, site))
+        self.assertTrue(multiple_requirements(self.dummy_request))
 
         mocked_get_user_roles_for_site.return_value = ["role2"]
-        self.assertTrue(multiple_requirements(user, site))
+        self.assertTrue(multiple_requirements(self.dummy_request))
 
         mocked_get_user_roles_for_site.return_value = ["role1", "role2"]
-        self.assertTrue(multiple_requirements(user, site))
+        self.assertTrue(multiple_requirements(self.dummy_request))
 
         # If the user has a role without the necessary permission,
         # then access is denied.
         mocked_get_user_roles_for_site.return_value = ["role3"]
         with self.assertRaises(utils.Forbidden):
-            single_requirement(user, site)
+            single_requirement(self.dummy_request)
 
+    @patch.dict("management_layer.mappings.SITE_CLIENT_ID_TO_ID_MAP",
+                TEST_SITE_CLIENT_ID_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.ROLE_LABEL_TO_ID_MAP",
                 TEST_ROLE_LABEL_TO_ID_MAP, clear=True)
     @patch.dict("management_layer.mappings.PERMISSION_NAME_TO_ID_MAP",
@@ -325,44 +320,42 @@ class TestRequirePermissionsDecorator(TestCase):
         @require_permissions(all, [("urn:resource1", "permission1")])
         @require_permissions(any, [("urn:resource2", "permission2"),
                                    ("urn:resource3", "permission3")])
-        def combo_requirement(_user, _site):
+        def combo_requirement(_request):
             return True
 
         # The values for the user and site is not important since this test
         # mocks the roles returned.
-        user = uuid1()
-        site = uuid1()
 
         # If the user has no roles, then access is denied.
         mocked_get_user_roles_for_site.return_value = []
         with self.assertRaises(utils.Forbidden):
-            combo_requirement(user, site)
+            combo_requirement(self.dummy_request)
 
         # If the user has roles partially fulfilling the required permissions,
         # then access is denied.
         mocked_get_user_roles_for_site.return_value = ["role1"]
         with self.assertRaises(utils.Forbidden):
-            combo_requirement(user, site)
+            combo_requirement(self.dummy_request)
 
         mocked_get_user_roles_for_site.return_value = ["role2"]
         with self.assertRaises(utils.Forbidden):
-            combo_requirement(user, site)
+            combo_requirement(self.dummy_request)
 
         mocked_get_user_roles_for_site.return_value = ["role3"]
         with self.assertRaises(utils.Forbidden):
-            combo_requirement(user, site)
+            combo_requirement(self.dummy_request)
 
         mocked_get_user_roles_for_site.return_value = ["role2", "role3"]
         with self.assertRaises(utils.Forbidden):
-            combo_requirement(user, site)
+            combo_requirement(self.dummy_request)
 
         # If the user has roles with the necessary permissions,
         # then access is allowed.
         mocked_get_user_roles_for_site.return_value = ["role1", "role2"]
-        self.assertTrue(combo_requirement(user, site))
+        self.assertTrue(combo_requirement(self.dummy_request))
 
         mocked_get_user_roles_for_site.return_value = ["role1", "role3"]
-        self.assertTrue(combo_requirement(user, site))
+        self.assertTrue(combo_requirement(self.dummy_request))
 
 
 class TestUtils(TestCase):

--- a/management_layer/permission/utils.py
+++ b/management_layer/permission/utils.py
@@ -30,25 +30,27 @@ Domain = typing.Union[str, int]
 Role = typing.Union[str, int]
 
 
-def json_serializer(key, value):
+def json_serializer(_key, value):
     if type(value) == str:
         return value, 1
     return json.dumps(value), 2
 
 
-def json_deserializer(key, value, flags):
+def json_deserializer(_key, value, flags):
     if flags == 1:
-        return value.decode('utf-8')
+        return value.decode("utf-8")
     if flags == 2:
-        return json.loads(value.decode('utf-8'))
+        return json.loads(value.decode("utf-8"))
     raise Exception("Unknown serialization format")
 
 
 # TODO: Tweak MemCache params
-MEMCACHE = PooledClient(("127.0.0.1", 11211),
-                        serializer=json_serializer,
-                        deserializer=json_deserializer,
-                        no_delay=True, connect_timeout=0.5, timeout=1.0)
+MEMCACHE = PooledClient(
+    ("127.0.0.1", 11211),
+    serializer=json_serializer,
+    deserializer=json_deserializer,
+    no_delay=True, connect_timeout=0.5, timeout=1.0
+)
 
 # TODO: These need to be pulled from a request.app["foo"] !! (cobusc)
 OA = access_control.api.OperationalApi()
@@ -64,8 +66,8 @@ class Forbidden(Exception):
 
 
 def role_has_permission(
-        role: Role, permission: Permission, resource: Resource,
-        nocache: bool = False
+    role: Role, permission: Permission, resource: Resource,
+    nocache: bool = False
 ) -> bool:
     """
     Check if a role has a specified resource permission.
@@ -91,10 +93,10 @@ def role_has_permission(
 
 
 def roles_have_permissions(
-        roles: typing.List[Role],
-        operator: Operator,
-        resource_permissions: ResourcePermissions,
-        nocache: bool = False
+    roles: typing.List[Role],
+    operator: Operator,
+    resource_permissions: ResourcePermissions,
+    nocache: bool = False
 ) -> bool:
     """
     Check whether the specified roles has any or all (as per the operator) of
@@ -131,12 +133,12 @@ def roles_have_permissions(
 
 
 def user_has_permissions(
-        user: UserId,
-        operator: Operator,
-        resource_permissions: ResourcePermissions,
-        site: SiteId = None,
-        domain: Domain = None,
-        nocache: bool = False
+    user: UserId,
+    operator: Operator,
+    resource_permissions: ResourcePermissions,
+    site: SiteId = None,
+    domain: Domain = None,
+    nocache: bool = False
 ) -> bool:
     """
     Check whether the specified user has any or all (as per the operator) of
@@ -167,8 +169,8 @@ def user_has_permissions(
 
 
 def get_user_roles_for_site_or_domain(
-        user: UserId, site: SiteId = None, domain: Domain = None, nocache:
-        bool = False
+    user: UserId, site: SiteId = None, domain: Domain = None, nocache:
+    bool = False
 ) -> typing.List[Role]:
     """
     Get the roles assigned to the user for the specified site or domain.
@@ -194,7 +196,7 @@ def get_user_roles_for_site_or_domain(
 
 
 def get_role_resource_permissions(
-        role: Role, resource: Resource, nocache: bool = False
+    role: Role, resource: Resource, nocache: bool = False
 ) -> typing.List[int]:
     """
     Get the permission granted on a resource for a specified role.
@@ -228,7 +230,7 @@ def get_role_resource_permissions(
 
 
 def get_all_user_roles(
-        user: UserId, nocache: bool = False
+    user: UserId, nocache: bool = False
 ) -> typing.Dict[str, typing.List[int]]:
     """
     This function returns all the roles that a user has on all sites and
@@ -275,7 +277,7 @@ def get_all_user_roles(
 
 
 def get_user_roles_for_domain(
-        user: UserId, domain: Domain, nocache: bool = False
+    user: UserId, domain: Domain, nocache: bool = False
 ) -> typing.List[int]:
     """
     Get the roles that a user has for a specified domain.
@@ -295,7 +297,7 @@ def get_user_roles_for_domain(
 
 
 def get_user_roles_for_site(
-        user: UserId, site: SiteId, nocache: bool = False
+    user: UserId, site: SiteId, nocache: bool = False
 ) -> typing.List[int]:
     """
     Get the roles that a user has for a specified site.

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -1119,7 +1119,7 @@ definitions:
       reuse_consent:
         description: >-
           If enabled, the Server will save the user consent given to a
-          specific client, so that user wont be prompted for the same
+          specific client, so that user will not be prompted for the same
           authorization multiple times.
         type: boolean
       terms_url:


### PR DESCRIPTION
User- and client IDs are now read from the token associated with a request.