### PR TITLE
Cobusc misc mods

### DIFF
--- a/httpd.py
+++ b/httpd.py
@@ -118,6 +118,7 @@ if __name__ == "__main__":
     logger.info("Access Control/Operational: {}".format(access_control_configuration.host))
     logger.info("Authentication Service: {}".format(authentication_service_configuration.host))
     logger.info("User Data Store: {}".format(user_data_store_configuration.host))
+    logger.info("Memcache: {}:{}".format(MEMCACHE_HOST, MEMCACHE_PORT))
 
     setup(app)  # Set up aiojobs scheduler
     app.on_startup.append(on_startup)

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -651,7 +651,7 @@ class Implementation(AbstractStubClass):
 
     # refresh_all -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:management_layer:refresh:all", "update")])
+    @require_permissions(any, [])  # Tech admin only
     async def refresh_all(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -663,7 +663,7 @@ class Implementation(AbstractStubClass):
 
     # refresh_domains -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:management_layer:refresh:domains", "update")])
+    @require_permissions(any, [])  # Tech admin only
     async def refresh_domains(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -675,7 +675,7 @@ class Implementation(AbstractStubClass):
 
     # refresh_permissions -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:management_layer:refresh:permissions", "update")])
+    @require_permissions(any, [])  # Tech admin only
     async def refresh_permissions(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -687,7 +687,7 @@ class Implementation(AbstractStubClass):
 
     # refresh_resources -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:management_layer:refresh:resources", "update")])
+    @require_permissions(any, [])  # Tech admin only
     async def refresh_resources(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -699,7 +699,7 @@ class Implementation(AbstractStubClass):
 
     # refresh_roles -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:management_layer:refresh:roles", "update")])
+    @require_permissions(any, [])  # Tech admin only
     async def refresh_roles(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -711,7 +711,7 @@ class Implementation(AbstractStubClass):
 
     # refresh_sites -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:management_layer:refresh:sites", "update")])
+    @require_permissions(any, [])  # Tech admin only
     async def refresh_sites(request, **kwargs):
         """
         :param request: An HttpRequest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 python_dateutil == 2.6.0
 aiomcache
 jsonschema
-aiohttp >= 3.1.0,<4.0
+aiohttp >= 3.1.1,<4.0
 aiohttp-cors
 aiojobs
 aiodns    # For use with aiohttp


### PR DESCRIPTION
* Bumped aiohttp version
* Expanded `@require_permissions(any, [])` test to include the case for a tech admin
* Log memcache config
* Reworked refresh_xxx calls' permissions. They are now using `@require_permissions(any, [])`
* Quick hack to get docker compose environment usable again until I can sort out the issue that arises in the Docker compose environment related to client disconnects when refreshing the mapping data.