### PR TITLE
GE-959: role assignment and revocation permission decorator

### DIFF
--- a/httpd.py
+++ b/httpd.py
@@ -13,8 +13,7 @@ import authentication_service
 import user_data_store
 from management_layer import settings, views
 from management_layer.api.urls import add_routes
-from management_layer.constants import TECH_ADMIN_ROLE_ID
-from management_layer.mappings import refresh_all
+from management_layer.mappings import refresh_all, return_tech_admin_role_for_testing
 from management_layer.middleware import auth_middleware, sentry_middleware
 from management_layer.settings import MEMCACHE_HOST, MEMCACHE_PORT, MAPPING_REFRESH_SLEEP_SECONDS
 from management_layer.permission import utils
@@ -53,16 +52,12 @@ async def on_shutdown(app):
     logger.info("Done.")
 
 
-async def mocked_return(_request, _user_id, _site_id, nocache=False):
-    return [TECH_ADMIN_ROLE_ID]
-
-
 if __name__ == "__main__":
     if settings.INSECURE:  # TODO: Remove before going to prod
         logger.info("*" * 29)
         logger.info("* Running in insecure mode! *")
         logger.info("*" * 29)
-        setattr(utils, "get_user_roles_for_site", mocked_return)
+        setattr(utils, "get_user_roles_for_site", return_tech_admin_role_for_testing)
 
     app = web.Application(middlewares=[
         auth_middleware, sentry_middleware

--- a/httpd.py
+++ b/httpd.py
@@ -13,7 +13,7 @@ import authentication_service
 import user_data_store
 from management_layer import settings, views
 from management_layer.api.urls import add_routes
-from management_layer.constants import TECH_ADMIN
+from management_layer.constants import TECH_ADMIN_ROLE_ID
 from management_layer.mappings import refresh_all
 from management_layer.middleware import auth_middleware, sentry_middleware
 from management_layer.settings import MEMCACHE_HOST, MEMCACHE_PORT, MAPPING_REFRESH_SLEEP_SECONDS
@@ -54,7 +54,7 @@ async def on_shutdown(app):
 
 
 async def mocked_return(_request, _user_id, _site_id, nocache=False):
-    return [TECH_ADMIN]
+    return [TECH_ADMIN_ROLE_ID]
 
 
 if __name__ == "__main__":

--- a/management_layer/constants.py
+++ b/management_layer/constants.py
@@ -2,6 +2,5 @@
 MKP_ROLE_RESOURCE_PERMISSION = "RRP"
 MKP_USER_ROLES = "UR"
 
-# The special tech admin role
+# The special tech admin role. We always identify this role using the label.
 TECH_ADMIN_ROLE_LABEL = "tech_admin"
-TECH_ADMIN_ROLE_ID = -1

--- a/management_layer/constants.py
+++ b/management_layer/constants.py
@@ -3,4 +3,5 @@ MKP_ROLE_RESOURCE_PERMISSION = "RRP"
 MKP_USER_ROLES = "UR"
 
 # The special tech admin role
-TECH_ADMIN = "tech_admin"
+TECH_ADMIN_ROLE_LABEL = "tech_admin"
+TECH_ADMIN_ROLE_ID = -1

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -1,7 +1,7 @@
 from management_layer.api.stubs import AbstractStubClass
 from management_layer import transformations, mappings
 from management_layer.utils import client_exception_handler
-from management_layer.permission.decorator import require_permissions
+from management_layer.permission.decorator import require_permissions, requester_has_role
 
 TOTAL_COUNT_HEADER = "X-Total-Count"
 CLIENT_TOTAL_COUNT_HEADER = "Content-Length"  # TODO: Use correct header
@@ -1331,6 +1331,7 @@ class Implementation(AbstractStubClass):
     # userdomainrole_create -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:access_control:userdomainrole", "create")])
+    @requester_has_role(body_field=1)
     async def userdomainrole_create(request, body, **kwargs):
         """
         :param request: An HttpRequest
@@ -1350,6 +1351,7 @@ class Implementation(AbstractStubClass):
     # userdomainrole_delete -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:access_control:userdomainrole", "delete")])
+    @requester_has_role(target_user_id_field=1, domain_id_field=2, role_id_field=3)
     async def userdomainrole_delete(request, user_id, domain_id, role_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1607,6 +1609,7 @@ class Implementation(AbstractStubClass):
     # usersiterole_create -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:access_control:usersiterole", "create")])
+    @requester_has_role(body_field=1)
     async def usersiterole_create(request, body, **kwargs):
         """
         :param request: An HttpRequest
@@ -1626,6 +1629,7 @@ class Implementation(AbstractStubClass):
     # usersiterole_delete -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:access_control:usersiterole", "delete")])
+    @requester_has_role(target_user_id_field=1, site_id_field=2, role_id_field=3)
     async def usersiterole_delete(request, user_id, site_id, role_id, **kwargs):
         """
         :param request: An HttpRequest

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -15,7 +15,8 @@ class Implementation(AbstractStubClass):
 
     # adminnote_list -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:user_data:adminnote", "read")])
+    @require_permissions(all, [("urn:ge:user_data:adminnote", "read")],
+                         target_user_field="creator_id")
     async def adminnote_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -45,6 +46,8 @@ class Implementation(AbstractStubClass):
         :param body: dict A dictionary containing the parsed and validated body
         :returns: result or (result, headers) tuple
         """
+        # The caller of this function is considered the creator.
+        body["creator_id"] = request["token"]["sub"]
         with client_exception_handler():
             admin_note = await request.app["user_data_api"].adminnote_create(data=body)
 
@@ -495,6 +498,13 @@ class Implementation(AbstractStubClass):
 
     # get_all_user_roles -- Synchronisation point for meld
     @staticmethod
+    @require_permissions(all, [("urn:ge:access_control:domain", "read"),
+                               ("urn:ge:access_control:site", "read"),
+                               ("urn:ge:access_control:domainrole", "read"),
+                               ("urn:ge:access_control:siterole", "read"),
+                               ("urn:ge:access_control:userdomainrole", "read"),
+                               ("urn:ge:access_control:usersiterole", "read"),
+                               ], target_user_field=1)
     async def get_all_user_roles(request, user_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -507,6 +517,8 @@ class Implementation(AbstractStubClass):
 
     # get_domain_roles -- Synchronisation point for meld
     @staticmethod
+    @require_permissions(all, [("urn:ge:access_control:domain", "read"),
+                               ("urn:ge:access_control:domainrole", "read")])
     async def get_domain_roles(request, domain_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -519,6 +531,10 @@ class Implementation(AbstractStubClass):
 
     # get_site_and_domain_roles -- Synchronisation point for meld
     @staticmethod
+    @require_permissions(all, [("urn:ge:access_control:domain", "read"),
+                               ("urn:ge:access_control:site", "read"),
+                               ("urn:ge:access_control:domainrole", "read"),
+                               ("urn:ge:access_control:siterole", "read")])
     async def get_site_and_domain_roles(request, site_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -531,6 +547,10 @@ class Implementation(AbstractStubClass):
 
     # get_site_role_labels_aggregated -- Synchronisation point for meld
     @staticmethod
+    @require_permissions(all, [("urn:ge:access_control:domain", "read"),
+                               ("urn:ge:access_control:site", "read"),
+                               ("urn:ge:access_control:domainrole", "read"),
+                               ("urn:ge:access_control:siterole", "read")])
     async def get_site_role_labels_aggregated(request, site_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -543,6 +563,13 @@ class Implementation(AbstractStubClass):
 
     # get_user_site_role_labels_aggregated -- Synchronisation point for meld
     @staticmethod
+    @require_permissions(all, [("urn:ge:access_control:domain", "read"),
+                               ("urn:ge:access_control:site", "read"),
+                               ("urn:ge:access_control:domainrole", "read"),
+                               ("urn:ge:access_control:siterole", "read"),
+                               ("urn:ge:access_control:userdomainrole", "read"),
+                               ("urn:ge:access_control:usersiterole", "read"),
+                               ], target_user_field=1)
     async def get_user_site_role_labels_aggregated(request, user_id, site_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1305,7 +1332,8 @@ class Implementation(AbstractStubClass):
 
     # userdomainrole_list -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:userdomainrole", "read")])
+    @require_permissions(all, [("urn:ge:access_control:userdomainrole", "read")],
+                         target_user_field="user_id")
     async def userdomainrole_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -1367,7 +1395,8 @@ class Implementation(AbstractStubClass):
 
     # userdomainrole_read -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:userdomainrole", "read")])
+    @require_permissions(all, [("urn:ge:access_control:userdomainrole", "read")],
+                         target_user_field=1)
     async def userdomainrole_read(request, user_id, domain_id, role_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1427,7 +1456,7 @@ class Implementation(AbstractStubClass):
 
     # user_read -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:identity_provider:user", "read")])
+    @require_permissions(all, [("urn:ge:identity_provider:user", "read")], target_user_field=1)
     async def user_read(request, user_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1446,7 +1475,7 @@ class Implementation(AbstractStubClass):
 
     # user_update -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:identity_provider:user", "update")])
+    @require_permissions(all, [("urn:ge:identity_provider:user", "update")], target_user_field=2)
     async def user_update(request, body, user_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1486,7 +1515,8 @@ class Implementation(AbstractStubClass):
 
     # usersitedata_list -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:user_data:usersitedata", "read")])
+    @require_permissions(all, [("urn:ge:user_data:usersitedata", "read")],
+                         target_user_field="user_id")
     async def usersitedata_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -1511,6 +1541,7 @@ class Implementation(AbstractStubClass):
     # usersitedata_create -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:user_data:usersitedata", "create")])
+    # The targeted user should not be allowed to make this call. This is admin only.
     async def usersitedata_create(request, body, **kwargs):
         """
         :param request: An HttpRequest
@@ -1530,6 +1561,7 @@ class Implementation(AbstractStubClass):
     # usersitedata_delete -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:user_data:usersitedata", "delete")])
+    # The targeted user should not be allowed to make this call. This is admin only.
     async def usersitedata_delete(request, user_id, site_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1544,7 +1576,7 @@ class Implementation(AbstractStubClass):
 
     # usersitedata_read -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:user_data:usersitedata", "read")])
+    @require_permissions(all, [("urn:ge:user_data:usersitedata", "read")], target_user_field=1)
     async def usersitedata_read(request, user_id, site_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1565,6 +1597,7 @@ class Implementation(AbstractStubClass):
     # usersitedata_update -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:user_data:usersitedata", "update")])
+    # The targeted user should not be allowed to make this call. This is admin only.
     async def usersitedata_update(request, body, user_id, site_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1583,7 +1616,8 @@ class Implementation(AbstractStubClass):
 
     # usersiterole_list -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:usersiterole", "read")])
+    @require_permissions(all, [("urn:ge:access_control:usersiterole", "read")],
+                         target_user_field="user_id")
     async def usersiterole_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -1645,7 +1679,7 @@ class Implementation(AbstractStubClass):
 
     # usersiterole_read -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:usersiterole", "read")])
+    @require_permissions(all, [("urn:ge:access_control:usersiterole", "read")], target_user_field=1)
     async def usersiterole_read(request, user_id, site_id, role_id, **kwargs):
         """
         :param request: An HttpRequest

--- a/management_layer/mappings.py
+++ b/management_layer/mappings.py
@@ -40,11 +40,11 @@ logger = logging.getLogger(__name__)
 
 class Mappings:
     # Internal copies of definitions. These are mappings of ids to dictionaries.
-    _domains = {}  # type: Dict[int, Dict]
-    _permissions = {}  # type: Dict[int, Dict]
-    _resources = {}  # type: Dict[int, Dict]
-    _roles = {}  # type: Dict[int, Dict]
-    _sites = {}  # type: Dict[int, Dict]
+    _domains = {}  # type: Dict[int, Dict] (refer to transformations.DOMAIN for more detail)
+    _permissions = {}  # type: Dict[int, Dict] (refer to transformations.PERMISSION for more detail)
+    _resources = {}  # type: Dict[int, Dict] (refer to transformations.RESOURCE for more detail)
+    _roles = {}  # type: Dict[int, Dict] (refer to transformations.ROLE for more detail)
+    _sites = {}  # type: Dict[int, Dict] (refer to transformations.SITE for more detail)
 
     # Name/label to id mappings.
     _domain_name_to_id_map = {}  # type: Dict[str, int]
@@ -55,7 +55,7 @@ class Mappings:
     _site_client_id_to_id_map = {}  # type: Dict[str, int]
 
     @classmethod
-    def domain_id_for(cls, name: str):
+    def domain_id_for(cls, name: str) -> int:
         try:
             return cls._domain_name_to_id_map[name]
         except KeyError:
@@ -63,7 +63,7 @@ class Mappings:
             raise
 
     @classmethod
-    def domain_name_for(cls, domain_id: int):
+    def domain_name_for(cls, domain_id: int) -> str:
         try:
             return cls._domains[domain_id]["name"]
         except KeyError:
@@ -71,7 +71,7 @@ class Mappings:
             raise
 
     @classmethod
-    def permission_id_for(cls, name: str):
+    def permission_id_for(cls, name: str) -> int:
         try:
             return cls._permission_name_to_id_map[name]
         except KeyError:
@@ -79,7 +79,7 @@ class Mappings:
             raise
 
     @classmethod
-    def permission_name_for(cls, permission_id: int):
+    def permission_name_for(cls, permission_id: int) -> str:
         try:
             return cls._permissions[permission_id]["name"]
         except KeyError:
@@ -87,7 +87,7 @@ class Mappings:
             raise
 
     @classmethod
-    def resource_id_for(cls, urn: str):
+    def resource_id_for(cls, urn: str) -> int:
         try:
             return cls._resource_urn_to_id_map[urn]
         except KeyError:
@@ -95,7 +95,7 @@ class Mappings:
             raise
 
     @classmethod
-    def resource_urn_for(cls, resource_id: int):
+    def resource_urn_for(cls, resource_id: int) -> str:
         try:
             return cls._resources[resource_id]["urn"]
         except KeyError:
@@ -103,7 +103,7 @@ class Mappings:
             raise
 
     @classmethod
-    def role_id_for(cls, label: str):
+    def role_id_for(cls, label: str) -> int:
         try:
             return cls._role_label_to_id_map[label]
         except KeyError:
@@ -111,7 +111,7 @@ class Mappings:
             raise
 
     @classmethod
-    def role_label_for(cls, role_id: int):
+    def role_label_for(cls, role_id: int) -> str:
         try:
             return cls._roles[role_id]["label"]
         except KeyError:
@@ -119,7 +119,7 @@ class Mappings:
             raise
 
     @classmethod
-    def site_id_for(cls, client_id: str):
+    def site_id_for(cls, client_id: str) -> int:
         try:
             return cls._site_client_id_to_id_map[client_id]
         except KeyError:
@@ -127,7 +127,7 @@ class Mappings:
             raise
 
     @classmethod
-    def site_name_for(cls, site_id: int):
+    def site_name_for(cls, site_id: int) -> str:
         try:
             return cls._sites[site_id]["name"]
         except KeyError:

--- a/management_layer/mappings.py
+++ b/management_layer/mappings.py
@@ -30,7 +30,7 @@ import aiomcache
 from aiohttp import web
 
 from management_layer import transformations
-from management_layer.constants import TECH_ADMIN_ROLE_LABEL, TECH_ADMIN_ROLE_ID
+from management_layer.constants import TECH_ADMIN_ROLE_LABEL
 from management_layer.settings import CACHE_TIME
 from management_layer.sentry import sentry
 from management_layer.utils import timeit
@@ -40,25 +40,99 @@ logger = logging.getLogger(__name__)
 
 class Mappings:
     # Internal copies of definitions. These are mappings of ids to dictionaries.
-    domains = {}  # type: Dict[int, Dict]
-    permissions = {}  # type: Dict[int, Dict]
-    resources = {}  # type: Dict[int, Dict]
-    roles = {
-        TECH_ADMIN_ROLE_ID: {
-            "label": TECH_ADMIN_ROLE_LABEL
-        }
-    }  # type: Dict[int, Dict]
-    sites = {}  # type: Dict[int, Dict]
+    _domains = {}  # type: Dict[int, Dict]
+    _permissions = {}  # type: Dict[int, Dict]
+    _resources = {}  # type: Dict[int, Dict]
+    _roles = {}  # type: Dict[int, Dict]
+    _sites = {}  # type: Dict[int, Dict]
 
     # Name/label to id mappings.
-    domain_name_to_id_map = {}  # type: Dict[str, int]
-    permission_name_to_id_map = {}  # type: Dict[str, int]
-    resource_urn_to_id_map = {}  # type: Dict[str, int]
-    role_label_to_id_map = {
-        TECH_ADMIN_ROLE_LABEL: TECH_ADMIN_ROLE_ID
-    }  # type: Dict[str, int]
-    site_name_to_id_map = {}  # type: Dict[str, int]
-    site_client_id_to_id_map = {}  # type: Dict[str, int]
+    _domain_name_to_id_map = {}  # type: Dict[str, int]
+    _permission_name_to_id_map = {}  # type: Dict[str, int]
+    _resource_urn_to_id_map = {}  # type: Dict[str, int]
+    _role_label_to_id_map = {}  # type: Dict[str, int]
+    _site_name_to_id_map = {}  # type: Dict[str, int]
+    _site_client_id_to_id_map = {}  # type: Dict[str, int]
+
+    @classmethod
+    def domain_id_for(cls, name: str):
+        try:
+            return cls._domain_name_to_id_map[name]
+        except KeyError:
+            logger.error(f"'{name}' not in {cls._domain_name_to_id_map}")
+            raise
+
+    @classmethod
+    def domain_name_for(cls, domain_id: int):
+        try:
+            return cls._domains[domain_id]["name"]
+        except KeyError:
+            logger.error(f"'{domain_id}' not in {cls._domains}")
+            raise
+
+    @classmethod
+    def permission_id_for(cls, name: str):
+        try:
+            return cls._permission_name_to_id_map[name]
+        except KeyError:
+            logger.error(f"'{name}' not in {cls._permission_name_to_id_map}")
+            raise
+
+    @classmethod
+    def permission_name_for(cls, permission_id: int):
+        try:
+            return cls._permissions[permission_id]["name"]
+        except KeyError:
+            logger.error(f"'{permission_id}' not in {cls._permissions}")
+            raise
+
+    @classmethod
+    def resource_id_for(cls, urn: str):
+        try:
+            return cls._resource_urn_to_id_map[urn]
+        except KeyError:
+            logger.error(f"'{urn}' not in {cls._resource_urn_to_id_map}")
+            raise
+
+    @classmethod
+    def resource_urn_for(cls, resource_id: int):
+        try:
+            return cls._resources[resource_id]["urn"]
+        except KeyError:
+            logger.error(f"'{resource_id}' not in {cls._resources}")
+            raise
+
+    @classmethod
+    def role_id_for(cls, label: str):
+        try:
+            return cls._role_label_to_id_map[label]
+        except KeyError:
+            logger.error(f"'{label}' not in {cls._role_label_to_id_map}")
+            raise
+
+    @classmethod
+    def role_label_for(cls, role_id: int):
+        try:
+            return cls._roles[role_id]["label"]
+        except KeyError:
+            logger.error(f"'{role_id}' not in {cls._roles}")
+            raise
+
+    @classmethod
+    def site_id_for(cls, client_id: str):
+        try:
+            return cls._site_client_id_to_id_map[client_id]
+        except KeyError:
+            logger.error(f"'{client_id}' not in {cls._site_client_id_to_id_map}")
+            raise
+
+    @classmethod
+    def site_name_for(cls, site_id: int):
+        try:
+            return cls._sites[site_id]["name"]
+        except KeyError:
+            logger.error(f"'{site_id}' not in {cls._sites}")
+            raise
 
 
 # Custom convenience type
@@ -126,7 +200,7 @@ async def refresh_domains(app: web.Application, nocache: bool=False):
     """Refresh the domain information"""
     logger.info("Refreshing domains")
     try:
-        Mappings.domains, Mappings.domain_name_to_id_map = await _load(
+        Mappings._domains, Mappings._domain_name_to_id_map = await _load(
             app["access_control_api"].domain_list, app["memcache"], transformations.DOMAIN,
             bytes(f"{__name__}:domains", encoding="utf8"), "name", nocache
         )
@@ -140,7 +214,7 @@ async def refresh_permissions(app: web.Application, nocache: bool=False):
     """Refresh the permission information"""
     logger.info("Refreshing permissions")
     try:
-        Mappings.permissions, Mappings.permission_name_to_id_map = await _load(
+        Mappings._permissions, Mappings._permission_name_to_id_map = await _load(
             app["access_control_api"].permission_list, app["memcache"], transformations.PERMISSION,
             bytes(f"{__name__}:permissions", encoding="utf8"), "name", nocache
         )
@@ -154,7 +228,7 @@ async def refresh_resources(app: web.Application, nocache: bool=False):
     """Refresh the resources information"""
     logger.info("Refreshing resources")
     try:
-        Mappings.resources, Mappings.resource_urn_to_id_map = await _load(
+        Mappings._resources, Mappings._resource_urn_to_id_map = await _load(
             app["access_control_api"].resource_list, app["memcache"], transformations.RESOURCE,
             bytes(f"{__name__}:resources", encoding="utf8"), "urn", nocache
         )
@@ -168,7 +242,7 @@ async def refresh_roles(app: web.Application, nocache: bool=False):
     """Refresh the roles information"""
     logger.info("Refreshing roles")
     try:
-        Mappings.roles, Mappings.role_label_to_id_map = await _load(
+        Mappings._roles, Mappings._role_label_to_id_map = await _load(
             app["access_control_api"].role_list, app["memcache"], transformations.ROLE,
             bytes(f"{__name__}:roles", encoding="utf8"), "label", nocache
         )
@@ -176,8 +250,9 @@ async def refresh_roles(app: web.Application, nocache: bool=False):
         sentry.captureException()
         logger.error(e)
 
-    Mappings.roles[TECH_ADMIN_ROLE_ID] = {"label": TECH_ADMIN_ROLE_LABEL}
-    Mappings.role_label_to_id_map[TECH_ADMIN_ROLE_LABEL] = TECH_ADMIN_ROLE_ID
+    # TODO: Remove this when loading data properly
+    Mappings._roles[-1] = {"label": TECH_ADMIN_ROLE_LABEL}
+    Mappings._role_label_to_id_map[TECH_ADMIN_ROLE_LABEL] = -1
 
 
 @timeit(TIMING_LOG_LEVEL)
@@ -185,18 +260,18 @@ async def refresh_sites(app: web.Application, nocache: bool=False):
     """Refresh the sites information"""
     logger.info("Refreshing sites")
     try:
-        Mappings.sites, Mappings.site_name_to_id_map = await _load(
+        Mappings._sites, Mappings._site_name_to_id_map = await _load(
             app["access_control_api"].site_list, app["memcache"], transformations.SITE,
             bytes(f"{__name__}:sites", encoding="utf8"), "name", nocache
         )
-        Mappings.site_client_id_to_id_map = {
-            detail["client_id"]: id_ for id_, detail in Mappings.sites.items()
+        Mappings._site_client_id_to_id_map = {
+            detail["client_id"]: id_ for id_, detail in Mappings._sites.items()
         }
     except Exception as e:
         sentry.captureException()
         logger.error(e)
 
-    Mappings.site_client_id_to_id_map["management_layer_workaround"] = 1  # TODO Workaround for now
+    Mappings._site_client_id_to_id_map["management_layer_workaround"] = 1  # TODO Workaround for now
 
 
 @timeit(TIMING_LOG_LEVEL)
@@ -210,3 +285,12 @@ async def refresh_all(app: web.Application, nocache: bool=False):
     await refresh_resources(app, nocache)
     await refresh_roles(app, nocache)
     await refresh_sites(app, nocache)
+
+
+async def return_tech_admin_role_for_testing(*args, **kwargs):
+    """
+    Many of the test functions require the availability of a function that will return a set
+    of roles containing the TECH_ADMIN role. This function does exactly that.
+    :return: A set containing the TECH_ADMIN role id
+    """
+    return {Mappings.role_id_for(TECH_ADMIN_ROLE_LABEL)}

--- a/management_layer/mappings.py
+++ b/management_layer/mappings.py
@@ -30,6 +30,7 @@ import aiomcache
 from aiohttp import web
 
 from management_layer import transformations
+from management_layer.constants import TECH_ADMIN_ROLE_LABEL, TECH_ADMIN_ROLE_ID
 from management_layer.settings import CACHE_TIME
 from management_layer.sentry import sentry
 from management_layer.utils import timeit
@@ -42,14 +43,20 @@ class Mappings:
     domains = {}  # type: Dict[int, Dict]
     permissions = {}  # type: Dict[int, Dict]
     resources = {}  # type: Dict[int, Dict]
-    roles = {}  # type: Dict[int, Dict]
+    roles = {
+        TECH_ADMIN_ROLE_ID: {
+            "label": TECH_ADMIN_ROLE_LABEL
+        }
+    }  # type: Dict[int, Dict]
     sites = {}  # type: Dict[int, Dict]
 
     # Name/label to id mappings.
     domain_name_to_id_map = {}  # type: Dict[str, int]
     permission_name_to_id_map = {}  # type: Dict[str, int]
     resource_urn_to_id_map = {}  # type: Dict[str, int]
-    role_label_to_id_map = {}  # type: Dict[str, int]
+    role_label_to_id_map = {
+        TECH_ADMIN_ROLE_LABEL: TECH_ADMIN_ROLE_ID
+    }  # type: Dict[str, int]
     site_name_to_id_map = {}  # type: Dict[str, int]
     site_client_id_to_id_map = {}  # type: Dict[str, int]
 
@@ -168,6 +175,9 @@ async def refresh_roles(app: web.Application, nocache: bool=False):
     except Exception as e:
         sentry.captureException()
         logger.error(e)
+
+    Mappings.roles[TECH_ADMIN_ROLE_ID] = {"label": TECH_ADMIN_ROLE_LABEL}
+    Mappings.role_label_to_id_map[TECH_ADMIN_ROLE_LABEL] = TECH_ADMIN_ROLE_ID
 
 
 @timeit(TIMING_LOG_LEVEL)

--- a/management_layer/permission/decorator.py
+++ b/management_layer/permission/decorator.py
@@ -11,18 +11,19 @@ from functools import wraps
 
 from aiohttp.web_exceptions import HTTPForbidden
 
+from management_layer.constants import TECH_ADMIN_ROLE_ID
 from management_layer.permission.utils import Operator, ResourcePermissions, \
-    user_has_permissions
+    user_has_permissions, get_user_roles_for_domain, get_user_roles_for_site
 from management_layer.mappings import Mappings
 
 logger = logging.getLogger(__name__)
 
 
 def require_permissions(
-    operator: Operator,
-    resource_permissions: ResourcePermissions,
-    nocache: bool = False,
-    request_field: typing.Union[int, str] = 0
+        operator: Operator,
+        resource_permissions: ResourcePermissions,
+        nocache: bool = False,
+        request_field: typing.Union[int, str] = 0
 ) -> typing.Callable:
     """
     This function is used as a decorator to protect functions by specifying
@@ -94,37 +95,17 @@ def require_permissions(
         @wraps(f)
         async def wrapped_f(*args, **kwargs):
             """
-            The purpose of the wrapper is to get the
             :param args: A list of positional arguments
             :param kwargs: A dictionary of keyword arguments
             :return: Whatever the wrapped function
             """
             # Extract the request from the function arguments
-            request_field_type = type(request_field)
-            if request_field_type is int:
-                request = args[request_field]
-            elif request_field_type is str:
-                request = kwargs[request_field]
-            else:
-                raise RuntimeError("Invalid value for request_field")
+            request = get_value_from_args_or_kwargs(request_field, args, kwargs)
 
-            # The request contains the JWT token payload from which we get
-            # * the user id from the "sub" (subscriber) field
-            # * the client id from the "aud" (audience) field
-
-            # Extract the user's UUID from the request
-            user = uuid.UUID(request["token"]["sub"])
-            # Extract the client id from the request
-            client_id = request["token"]["aud"]
-            if client_id not in Mappings.site_client_id_to_id_map:
-                raise HTTPForbidden(body=json.dumps({
-                    "message": f"No site linked to the client '{client_id}'"
-                }))
-
-            site_id = Mappings.site_client_id_to_id_map[client_id]
+            user_id, site_id = get_user_and_site(request)
 
             allowed = await user_has_permissions(
-                request, user, operator, resource_permissions,
+                request, user_id, operator, resource_permissions,
                 site=site_id, nocache=nocache,
             )
             if allowed:
@@ -140,3 +121,165 @@ def require_permissions(
         return wrapped_f
 
     return wrap
+
+
+def requester_has_role(
+        nocache: bool = False,
+        request_field: typing.Union[int, str] = 0,
+        body_field: typing.Union[int, str] = None,
+        target_user_id_field: typing.Union[int, str] = None,
+        role_id_field: typing.Union[int, str] = None,
+        domain_id_field: typing.Union[int, str] = None,
+        site_id_field: typing.Union[int, str] = None
+) -> typing.Callable:
+    """
+    This function is used as a decorator to protect functions that add and remove roles on
+    domains and sites to users, e.g.
+    ```
+    @requester_has_role()
+    def usersiterole_create(request, body, **kwargs):
+        pass
+    ```
+    The body must contain the user_id of the recipient, the role_id of the role that must be
+    assigned and the site_id of the site for which the user will must get the role.
+    ```
+    @requester_has_role()
+    def usersiterole_delete(request, user_id, site_id, role_id, **kwargs):
+        pass
+    ```
+    The user making the request is inferred from the token passed with the request.
+
+    IMPORTANT: This decorator can be applied to both coroutines and normal functions AND it
+    always changes the decorated function into a coroutine, meaning it must be called using `await`:
+    ```
+    @requester_has_role()
+    def doSomething(request, body):
+        pass
+
+    # Call the function
+    result = await doSomething(request, body)  # Decorator change function to coroutine
+    ```
+
+    :param nocache: Bypass the cache if True
+    :param request_field: An integer or string identifying either the positional
+        argument or the name of the keyword argument identifying the request parameter.
+    :param body_field: An integer or string identifying either the positional
+        argument or the name of the keyword argument identifying the body parameter. The
+        body parameter is a dictionary that can contain a user_id, role_id and either a
+        site_id or domain_id, depending in the call.
+    :param target_user_id_field: An integer or string identifying either the positional argument
+        or the name of the keyword argument identifying the user_id field of the target user,
+        i.e. the user for which a role must be set or removed.
+    :param role_id_field: An integer or string identifying either the positional argument
+        or the name of the keyword argument identifying the role_id field.
+    :param domain_id_field: An integer or string identifying either the positional argument
+        or the name of the keyword argument identifying the domain_id field.
+    :param site_id_field: An integer or string identifying either the positional argument
+        or the name of the keyword argument identifying the site_id field.
+    :raises: Forbidden if the user does not have the role that is being invoked or revoked.
+    """
+
+    def wrap(f):
+        @wraps(f)
+        async def wrapped_f(*args, **kwargs):
+            """
+            :param args: A list of positional arguments
+            :param kwargs: A dictionary of keyword arguments
+            :return: Whatever the wrapped function
+            """
+            # Extract the request from the function arguments
+            request = get_value_from_args_or_kwargs(request_field, args, kwargs)
+
+            user_id, site_id = get_user_and_site(request)
+
+            # Extract the user_id for which a role must be a assigned/revoked
+            target_user_id = get_value_from_args_or_kwargs(target_user_id_field, args, kwargs)
+
+            if body_field is not None:
+                body = get_value_from_args_or_kwargs(body_field, args, kwargs)
+
+                # When the body is specified, the xxx_field arguments must be the names of the
+                # fields in the body dictionary.
+                role_id = body[role_id_field or "role_id"]
+                # We expect either a domain_id or a site_id to be provided
+                domain_id = body.get(domain_id_field or "domain_id")
+                site_id = body.get(site_id_field or "site_id")
+                if domain_id is None and site_id is None or \
+                        domain_id is not None and site_id is not None:
+                    raise RuntimeError("Either a domain_id or site_id needs to exist in the body")
+            else:
+                # If a body is not specified, the rest of the arguments are considered to be
+                # positional arguments.
+                role_id = get_value_from_args_or_kwargs(role_id_field, args, kwargs)
+                if domain_id_field is None and site_id_field is None or \
+                        domain_id_field is not None and site_id_field is not None:
+                    raise RuntimeError("Either a domain_id_field or site_id_field needs to defined")
+
+                if domain_id_field:
+                    domain_id = get_value_from_args_or_kwargs(domain_id_field, args, kwargs)
+                else:
+                    site_id = get_value_from_args_or_kwargs(site_id_field, args, kwargs)
+
+            if domain_id:
+                user_roles = await get_user_roles_for_domain(request, user_id, domain_id, nocache)
+            else:  # Use site_id
+                user_roles = await get_user_roles_for_site(request, user_id, site_id, nocache)
+
+            # If the user roles contains the one we want to assign or Tech Admin, we allow
+            # the call to proceed.
+            if user_roles.intersection([role_id, TECH_ADMIN_ROLE_ID]):
+                if asyncio.iscoroutinefunction(f):
+                    return await f(*args, **kwargs)
+                else:
+                    return f(*args, **kwargs)
+
+            raise HTTPForbidden(body=json.dumps({
+                "message": "Forbidden"
+            }))
+
+        return wrapped_f
+
+    return wrap
+
+
+def get_value_from_args_or_kwargs(
+        argument_identifier: typing.Union[int, str],
+        args: typing.Tuple[typing.Any, ...], kwargs: dict
+):
+    """
+
+    :param argument_identifier: The index or name of a function argument
+    :param args: A list of positional arguments
+    :param kwargs: A dictionary of named arguments
+    :return: The value of the argument.
+    """
+    argument_identifier_type = type(argument_identifier)
+    if argument_identifier_type is int:
+        return args[argument_identifier]
+
+    if argument_identifier_type is str:
+        return kwargs[argument_identifier]
+
+    raise RuntimeError("Invalid value for argument identifier")
+
+
+def get_user_and_site(request):
+    """
+    A request contains the JWT token payload from which we get
+    * the user id from the "sub" (subscriber) field
+    * the client id from the "aud" (audience) field
+    :param request: An HttpRequest
+    :return: A (user_id, site_id) tuple.
+    :raises: HTTPForbidden if the token's client id does not map to a site id.
+    """
+    # Extract the user's UUID from the request
+    user_id = uuid.UUID(request["token"]["sub"])
+    # Extract the client id from the request
+    client_id = request["token"]["aud"]
+    if client_id not in Mappings.site_client_id_to_id_map:
+        raise HTTPForbidden(body=json.dumps({
+            "message": f"No site linked to the client '{client_id}'"
+        }))
+
+    site_id = Mappings.site_client_id_to_id_map[client_id]
+    return user_id, site_id

--- a/management_layer/permission/decorator.py
+++ b/management_layer/permission/decorator.py
@@ -127,7 +127,9 @@ def require_permissions(
                 # For some calls the specified field may be optional
                 try:
                     target_user_id = _get_value_from_args_or_kwargs(target_user_field, args, kwargs)
-                    allowed = (user_id == target_user_id)
+                    # We cast the values to strings when comparing, to that both strings and UUIDs
+                    # can be used.
+                    allowed = (str(user_id) == str(target_user_id))
                 except KeyError:
                     pass
 

--- a/management_layer/permission/utils.py
+++ b/management_layer/permission/utils.py
@@ -6,18 +6,21 @@ Permissions are based on the roles assigned to the user making the request,
 which maps to permissions on resources.
 """
 import json
+import logging
 import typing
 from uuid import UUID
 
 from aiohttp.web import Request
 
 from management_layer.constants import MKP_ROLE_RESOURCE_PERMISSION, \
-    MKP_USER_ROLES, TECH_ADMIN_ROLE_ID
+    MKP_USER_ROLES, TECH_ADMIN_ROLE_LABEL
 from management_layer.mappings import Mappings
 from management_layer.settings import CACHE_TIME
 
 # Convenience types
 from management_layer.utils import client_exception_handler
+
+logger = logging.getLogger(__name__)
 
 UserId = type(UUID)
 SiteId = int
@@ -49,7 +52,7 @@ async def role_has_permission(
     """
     result = False
     permission_id = permission if type(permission) is int else \
-        Mappings.permission_name_to_id_map[permission]
+        Mappings.permission_id_for(permission)
 
     permission_ids = await get_role_resource_permissions(request, role, resource, nocache=nocache)
     if permission_ids:
@@ -90,9 +93,9 @@ async def roles_have_permissions(
         raise RuntimeError("The operator must be all or any")
 
     # Normalise to ids
-    roles = {role if type(role) is int else Mappings.role_label_to_id_map[role] for role in roles}
+    roles = {role if type(role) is int else Mappings.role_id_for(role) for role in roles}
 
-    if TECH_ADMIN_ROLE_ID in roles:
+    if Mappings.role_id_for(TECH_ADMIN_ROLE_LABEL) in roles:
         return True
 
     # This code snippet was originally used before the utility functions were changed
@@ -108,7 +111,7 @@ async def roles_have_permissions(
     for resource, permission in resource_permissions:
         some_role_has_the_permission = False
         for role in roles:
-            if await role_has_permission(request, role, permission, resource, nocache):
+            if await role_has_permission(request, role, permission, resource, nocache=nocache):
                 some_role_has_the_permission = True
                 break  # No need to look further
 
@@ -166,7 +169,7 @@ async def user_has_permissions(
 async def get_user_roles_for_site_or_domain(
     request: Request, user: UserId,
     site: SiteId = None, domain: Domain = None, nocache: bool = False
-) -> typing.List[Role]:
+) -> typing.Set[int]:
     """
     Get the roles assigned to the user for the specified site or domain.
     Either a site or a domain needs to be specified.
@@ -184,9 +187,9 @@ async def get_user_roles_for_site_or_domain(
         raise RuntimeError("Either a site or a domain needs to be provided")
 
     if domain:
-        result = await get_user_roles_for_domain(request, user, domain, nocache)
+        result = await get_user_roles_for_domain(request, user, domain, nocache=nocache)
     else:
-        result = await get_user_roles_for_site(request, user, site, nocache)
+        result = await get_user_roles_for_site(request, user, site, nocache=nocache)
 
     return result
 
@@ -205,9 +208,9 @@ async def get_role_resource_permissions(
     :param nocache: Bypass the cache if True
     :return: A list of permission ids
     """
-    role_id = role if type(role) is int else Mappings.role_label_to_id_map[role]
+    role_id = role if type(role) is int else Mappings.role_id_for(role)
     resource_id = resource if type(resource) is int else \
-        Mappings.resource_urn_to_id_map[resource]
+        Mappings.resource_id_for(resource)
 
     key = bytes(f"{MKP_ROLE_RESOURCE_PERMISSION}:{role_id}:{resource_id}",
                 encoding="utf8")
@@ -304,7 +307,7 @@ async def get_user_roles_for_domain(
     :param nocache: Bypass the cache if True
     :return: A set of role ids
     """
-    domain_id = domain if type(domain) is int else Mappings.domain_name_to_id_map[domain]
+    domain_id = domain if type(domain) is int else Mappings.domain_id_for(domain)
 
     user_roles = await get_all_user_roles(request, user, nocache)
     # Look up the list of role ids associated with the domain key. Return an
@@ -325,7 +328,7 @@ async def get_user_roles_for_site(
     :param nocache: Bypass the cache if True
     :return: A set of role ids
     """
-    site_id = site if type(site) is int else Mappings.site_name_to_id_map[site]
+    site_id = site if type(site) is int else Mappings.site_id_for(site)
 
     user_roles = await get_all_user_roles(request, user, nocache)
     # Look up the list of role ids associated with the site key. Return an

--- a/management_layer/tests/test_integration.py
+++ b/management_layer/tests/test_integration.py
@@ -22,9 +22,8 @@ import access_control
 import authentication_service
 import user_data_store
 from management_layer.constants import TECH_ADMIN_ROLE_LABEL
-from management_layer.mappings import Mappings, return_tech_admin_role_for_testing
+from management_layer.mappings import return_tech_admin_role_for_testing
 from management_layer.middleware import auth_middleware
-from management_layer.tests import make_coroutine_returning
 from user_data_store import UserDataApi
 from management_layer.api import schemas
 from management_layer.api.urls import add_routes

--- a/management_layer/tests/test_integration.py
+++ b/management_layer/tests/test_integration.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 import access_control
 import authentication_service
 import user_data_store
-from management_layer.constants import TECH_ADMIN
+from management_layer.constants import TECH_ADMIN_ROLE_LABEL
 from management_layer.middleware import auth_middleware
 from management_layer.tests import make_coroutine_returning
 from user_data_store import UserDataApi
@@ -245,7 +245,7 @@ class ExampleTestCase(AioHTTPTestCase):
 @patch.multiple("management_layer.mappings.Mappings",
                 site_client_id_to_id_map={os.environ["JWT_AUDIENCE"]: 1})
 @patch("management_layer.permission.utils.get_user_roles_for_site",
-       Mock(side_effect=make_coroutine_returning([TECH_ADMIN])))
+       Mock(side_effect=make_coroutine_returning([TECH_ADMIN_ROLE_LABEL])))
 class IntegrationTest(AioHTTPTestCase):
     """
     Test functionality in integration.py


### PR DESCRIPTION
Added decorator that will check whether the user that wants to assign or remove a role on a domain or site to another user, has that role. Example:
```
@requester_has_role(body_field=1)
def usersiterole_create(request, body, **kwargs):
    ...
```
The body must contain the `user_id` of the recipient, the `role_id` of the role that must be assigned and the `site_id` of the site for which the user will must get the role.

```
@requester_has_role(target_user_id_field=1, site_id_field=2, role_id_field=3)
def usersiterole_delete(request, user_id, site_id, role_id, **kwargs):
      ...
```
Advanced:
```
@requester_has_role(request_field=1, body_field=0, target_user_id_field="some_user",
                    site_id_field="some_site", role_id_field="some_role")
def call_with_body(body, request, **kwargs):  # Note that request is not first
    return True
```