### PR TITLE
Reworked invitation API based on Access Control modifications

### DIFF
--- a/access_control/models/invitation.py
+++ b/access_control/models/invitation.py
@@ -36,6 +36,7 @@ class Invitation(object):
         'first_name': 'str',
         'last_name': 'str',
         'email': 'str',
+        'organisation_id': 'int',
         'expires_at': 'datetime',
         'created_at': 'datetime',
         'updated_at': 'datetime'
@@ -47,12 +48,13 @@ class Invitation(object):
         'first_name': 'first_name',
         'last_name': 'last_name',
         'email': 'email',
+        'organisation_id': 'organisation_id',
         'expires_at': 'expires_at',
         'created_at': 'created_at',
         'updated_at': 'updated_at'
     }
 
-    def __init__(self, id=None, invitor_id=None, first_name=None, last_name=None, email=None, expires_at=None, created_at=None, updated_at=None):  # noqa: E501
+    def __init__(self, id=None, invitor_id=None, first_name=None, last_name=None, email=None, organisation_id=None, expires_at=None, created_at=None, updated_at=None):  # noqa: E501
         """Invitation - a model defined in OpenAPI"""  # noqa: E501
 
         self._id = None
@@ -60,6 +62,7 @@ class Invitation(object):
         self._first_name = None
         self._last_name = None
         self._email = None
+        self._organisation_id = None
         self._expires_at = None
         self._created_at = None
         self._updated_at = None
@@ -70,6 +73,7 @@ class Invitation(object):
         self.first_name = first_name
         self.last_name = last_name
         self.email = email
+        self.organisation_id = organisation_id
         self.expires_at = expires_at
         self.created_at = created_at
         self.updated_at = updated_at
@@ -194,6 +198,29 @@ class Invitation(object):
             raise ValueError("Invalid value for `email`, must not be `None`")  # noqa: E501
 
         self._email = email
+
+    @property
+    def organisation_id(self):
+        """Gets the organisation_id of this Invitation.  # noqa: E501
+
+
+        :return: The organisation_id of this Invitation.  # noqa: E501
+        :rtype: int
+        """
+        return self._organisation_id
+
+    @organisation_id.setter
+    def organisation_id(self, organisation_id):
+        """Sets the organisation_id of this Invitation.
+
+
+        :param organisation_id: The organisation_id of this Invitation.  # noqa: E501
+        :type: int
+        """
+        if organisation_id is None:
+            raise ValueError("Invalid value for `organisation_id`, must not be `None`")  # noqa: E501
+
+        self._organisation_id = organisation_id
 
     @property
     def expires_at(self):

--- a/access_control/models/invitation_create.py
+++ b/access_control/models/invitation_create.py
@@ -35,6 +35,7 @@ class InvitationCreate(object):
         'first_name': 'str',
         'last_name': 'str',
         'email': 'str',
+        'organisation_id': 'int',
         'expires_at': 'datetime'
     }
 
@@ -43,16 +44,18 @@ class InvitationCreate(object):
         'first_name': 'first_name',
         'last_name': 'last_name',
         'email': 'email',
+        'organisation_id': 'organisation_id',
         'expires_at': 'expires_at'
     }
 
-    def __init__(self, invitor_id=None, first_name=None, last_name=None, email=None, expires_at=None):  # noqa: E501
+    def __init__(self, invitor_id=None, first_name=None, last_name=None, email=None, organisation_id=None, expires_at=None):  # noqa: E501
         """InvitationCreate - a model defined in OpenAPI"""  # noqa: E501
 
         self._invitor_id = None
         self._first_name = None
         self._last_name = None
         self._email = None
+        self._organisation_id = None
         self._expires_at = None
         self.discriminator = None
 
@@ -60,6 +63,7 @@ class InvitationCreate(object):
         self.first_name = first_name
         self.last_name = last_name
         self.email = email
+        self.organisation_id = organisation_id
         if expires_at is not None:
             self.expires_at = expires_at
 
@@ -160,6 +164,29 @@ class InvitationCreate(object):
             raise ValueError("Invalid value for `email`, must not be `None`")  # noqa: E501
 
         self._email = email
+
+    @property
+    def organisation_id(self):
+        """Gets the organisation_id of this InvitationCreate.  # noqa: E501
+
+
+        :return: The organisation_id of this InvitationCreate.  # noqa: E501
+        :rtype: int
+        """
+        return self._organisation_id
+
+    @organisation_id.setter
+    def organisation_id(self, organisation_id):
+        """Sets the organisation_id of this InvitationCreate.
+
+
+        :param organisation_id: The organisation_id of this InvitationCreate.  # noqa: E501
+        :type: int
+        """
+        if organisation_id is None:
+            raise ValueError("Invalid value for `organisation_id`, must not be `None`")  # noqa: E501
+
+        self._organisation_id = organisation_id
 
     @property
     def expires_at(self):

--- a/access_control/models/invitation_update.py
+++ b/access_control/models/invitation_update.py
@@ -31,36 +31,69 @@ class InvitationUpdate(object):
                             and the value is json key in definition.
     """
     openapi_types = {
+        'invitor_id': 'str',
         'first_name': 'str',
         'last_name': 'str',
         'email': 'str',
+        'organisation_id': 'int',
         'expires_at': 'datetime'
     }
 
     attribute_map = {
+        'invitor_id': 'invitor_id',
         'first_name': 'first_name',
         'last_name': 'last_name',
         'email': 'email',
+        'organisation_id': 'organisation_id',
         'expires_at': 'expires_at'
     }
 
-    def __init__(self, first_name=None, last_name=None, email=None, expires_at=None):  # noqa: E501
+    def __init__(self, invitor_id=None, first_name=None, last_name=None, email=None, organisation_id=None, expires_at=None):  # noqa: E501
         """InvitationUpdate - a model defined in OpenAPI"""  # noqa: E501
 
+        self._invitor_id = None
         self._first_name = None
         self._last_name = None
         self._email = None
+        self._organisation_id = None
         self._expires_at = None
         self.discriminator = None
 
+        if invitor_id is not None:
+            self.invitor_id = invitor_id
         if first_name is not None:
             self.first_name = first_name
         if last_name is not None:
             self.last_name = last_name
         if email is not None:
             self.email = email
+        if organisation_id is not None:
+            self.organisation_id = organisation_id
         if expires_at is not None:
             self.expires_at = expires_at
+
+    @property
+    def invitor_id(self):
+        """Gets the invitor_id of this InvitationUpdate.  # noqa: E501
+
+        The user that created the invitation  # noqa: E501
+
+        :return: The invitor_id of this InvitationUpdate.  # noqa: E501
+        :rtype: str
+        """
+        return self._invitor_id
+
+    @invitor_id.setter
+    def invitor_id(self, invitor_id):
+        """Sets the invitor_id of this InvitationUpdate.
+
+        The user that created the invitation  # noqa: E501
+
+        :param invitor_id: The invitor_id of this InvitationUpdate.  # noqa: E501
+        :type: str
+        """
+
+        self._invitor_id = invitor_id
 
     @property
     def first_name(self):
@@ -128,6 +161,27 @@ class InvitationUpdate(object):
         """
 
         self._email = email
+
+    @property
+    def organisation_id(self):
+        """Gets the organisation_id of this InvitationUpdate.  # noqa: E501
+
+
+        :return: The organisation_id of this InvitationUpdate.  # noqa: E501
+        :rtype: int
+        """
+        return self._organisation_id
+
+    @organisation_id.setter
+    def organisation_id(self, organisation_id):
+        """Sets the organisation_id of this InvitationUpdate.
+
+
+        :param organisation_id: The organisation_id of this InvitationUpdate.  # noqa: E501
+        :type: int
+        """
+
+        self._organisation_id = organisation_id
 
     @property
     def expires_at(self):

--- a/management_layer/api/schemas.py
+++ b/management_layer/api/schemas.py
@@ -504,6 +504,7 @@ invitation = json.loads("""
         "invitor_id": {
             "description": "The user that created the invitation",
             "format": "uuid",
+            "readOnly": true,
             "type": "string",
             "x-related-info": {
                 "label": "username",
@@ -513,6 +514,13 @@ invitation = json.loads("""
         "last_name": {
             "maxLength": 100,
             "type": "string"
+        },
+        "organisation_id": {
+            "type": "integer",
+            "x-related-info": {
+                "label": "name",
+                "model": "organisationalunit"
+            }
         },
         "updated_at": {
             "format": "date-time",
@@ -526,6 +534,7 @@ invitation = json.loads("""
         "first_name",
         "last_name",
         "email",
+        "organisation_id",
         "expires_at",
         "created_at",
         "updated_at"
@@ -549,25 +558,23 @@ invitation_create = json.loads("""
             "maxLength": 100,
             "type": "string"
         },
-        "invitor_id": {
-            "description": "The user that created the invitation",
-            "format": "uuid",
-            "type": "string",
-            "x-related-info": {
-                "label": "username",
-                "model": "user"
-            }
-        },
         "last_name": {
             "maxLength": 100,
             "type": "string"
+        },
+        "organisation_id": {
+            "type": "integer",
+            "x-related-info": {
+                "label": "name",
+                "model": "organisationalunit"
+            }
         }
     },
     "required": [
-        "invitor_id",
         "first_name",
         "last_name",
-        "email"
+        "email",
+        "organisation_id"
     ],
     "type": "object"
 }
@@ -744,6 +751,13 @@ invitation_update = json.loads("""
         "last_name": {
             "maxLength": 100,
             "type": "string"
+        },
+        "organisation_id": {
+            "type": "integer",
+            "x-related-info": {
+                "label": "name",
+                "model": "organisationalunit"
+            }
         }
     },
     "type": "object"

--- a/management_layer/api/stubs.py
+++ b/management_layer/api/stubs.py
@@ -1958,6 +1958,7 @@ class MockedStubClass(AbstractStubClass):
             "invitor_id": {
                 "description": "The user that created the invitation",
                 "format": "uuid",
+                "readOnly": true,
                 "type": "string",
                 "x-related-info": {
                     "label": "username",
@@ -1967,6 +1968,13 @@ class MockedStubClass(AbstractStubClass):
             "last_name": {
                 "maxLength": 100,
                 "type": "string"
+            },
+            "organisation_id": {
+                "type": "integer",
+                "x-related-info": {
+                    "label": "name",
+                    "model": "organisationalunit"
+                }
             },
             "updated_at": {
                 "format": "date-time",
@@ -1980,6 +1988,7 @@ class MockedStubClass(AbstractStubClass):
             "first_name",
             "last_name",
             "email",
+            "organisation_id",
             "expires_at",
             "created_at",
             "updated_at"

--- a/management_layer/api/views.py
+++ b/management_layer/api/views.py
@@ -1338,6 +1338,7 @@ class Invitations(View, CorsViewMixin):
             "invitor_id": {
                 "description": "The user that created the invitation",
                 "format": "uuid",
+                "readOnly": true,
                 "type": "string",
                 "x-related-info": {
                     "label": "username",
@@ -1347,6 +1348,13 @@ class Invitations(View, CorsViewMixin):
             "last_name": {
                 "maxLength": 100,
                 "type": "string"
+            },
+            "organisation_id": {
+                "type": "integer",
+                "x-related-info": {
+                    "label": "name",
+                    "model": "organisationalunit"
+                }
             },
             "updated_at": {
                 "format": "date-time",
@@ -1360,6 +1368,7 @@ class Invitations(View, CorsViewMixin):
             "first_name",
             "last_name",
             "email",
+            "organisation_id",
             "expires_at",
             "created_at",
             "updated_at"
@@ -6082,6 +6091,7 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
                 "invitor_id": {
                     "description": "The user that created the invitation",
                     "format": "uuid",
+                    "readOnly": true,
                     "type": "string",
                     "x-related-info": {
                         "label": "username",
@@ -6091,6 +6101,13 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
                 "last_name": {
                     "maxLength": 100,
                     "type": "string"
+                },
+                "organisation_id": {
+                    "type": "integer",
+                    "x-related-info": {
+                        "label": "name",
+                        "model": "organisationalunit"
+                    }
                 },
                 "updated_at": {
                     "format": "date-time",
@@ -6104,6 +6121,7 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
                 "first_name",
                 "last_name",
                 "email",
+                "organisation_id",
                 "expires_at",
                 "created_at",
                 "updated_at"
@@ -6124,25 +6142,23 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
                     "maxLength": 100,
                     "type": "string"
                 },
-                "invitor_id": {
-                    "description": "The user that created the invitation",
-                    "format": "uuid",
-                    "type": "string",
-                    "x-related-info": {
-                        "label": "username",
-                        "model": "user"
-                    }
-                },
                 "last_name": {
                     "maxLength": 100,
                     "type": "string"
+                },
+                "organisation_id": {
+                    "type": "integer",
+                    "x-related-info": {
+                        "label": "name",
+                        "model": "organisationalunit"
+                    }
                 }
             },
             "required": [
-                "invitor_id",
                 "first_name",
                 "last_name",
-                "email"
+                "email",
+                "organisation_id"
             ],
             "type": "object"
         },
@@ -6304,6 +6320,13 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
                 "last_name": {
                     "maxLength": 100,
                     "type": "string"
+                },
+                "organisation_id": {
+                    "type": "integer",
+                    "x-related-info": {
+                        "label": "name",
+                        "model": "organisationalunit"
+                    }
                 }
             },
             "type": "object"

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -61,6 +61,7 @@ class Implementation(AbstractStubClass):
         """
         # The caller of this function is considered the creator.
         body["creator_id"] = request["token"]["sub"]
+
         with client_exception_handler():
             admin_note = await request.app["user_data_api"].adminnote_create(admin_note_create=body)
 
@@ -570,6 +571,9 @@ class Implementation(AbstractStubClass):
         :param body: dict A dictionary containing the parsed and validated body
         :returns: result or (result, headers) tuple
         """
+        # The caller of this function is considered the invitor.
+        body["invitor_id"] = request["token"]["sub"]
+
         with client_exception_handler():
             invitation = await request.app["access_control_api"].invitation_create(
                 invitation_create=body)

--- a/management_layer/transformations.py
+++ b/management_layer/transformations.py
@@ -46,7 +46,7 @@ INVITATION = Transformation(
         Mapping("expires_at", conversion=datetime_to_string)
     ],
     copy_fields=["id", "first_name", "last_name", "email",
-                 "invitor_id", "is_system_user"]
+                 "invitor_id", "organisation_id"]
 )
 
 INVITATION_DOMAIN_ROLE = Transformation(

--- a/swagger/access_control.yml
+++ b/swagger/access_control.yml
@@ -628,6 +628,8 @@ definitions:
       email:
         type: string
         format: email
+      organisation_id:
+        type: integer
       expires_at:
         type: string
         format: 'date-time'
@@ -645,6 +647,7 @@ definitions:
       - first_name
       - last_name
       - email
+      - organisation_id
       - expires_at
       - created_at
       - updated_at
@@ -665,6 +668,8 @@ definitions:
       email:
         type: string
         format: email
+      organisation_id:
+        type: integer
       expires_at:
         type: string
         format: 'date-time'
@@ -673,10 +678,15 @@ definitions:
       - first_name
       - last_name
       - email
+      - organisation_id
 
   invitation_update:
     type: object
     properties:
+      invitor_id:
+        type: string
+        format: uuid
+        description: The user that created the invitation
       first_name:
         type: string
         maxLength: 100
@@ -686,6 +696,8 @@ definitions:
       email:
         type: string
         format: email
+      organisation_id:
+        type: integer
       expires_at:
         type: string
         format: 'date-time'

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -780,6 +780,7 @@ definitions:
         type: string
         format: uuid
         description: The user that created the invitation
+        readOnly: true
         x-related-info:
           model: user
           label: username
@@ -792,6 +793,11 @@ definitions:
       email:
         type: string
         format: email
+      organisation_id:
+        type: integer
+        x-related-info:
+          model: organisationalunit
+          label: name
       expires_at:
         type: string
         format: 'date-time'
@@ -809,6 +815,7 @@ definitions:
       - first_name
       - last_name
       - email
+      - organisation_id
       - expires_at
       - created_at
       - updated_at
@@ -816,13 +823,6 @@ definitions:
   invitation_create:
     type: object
     properties:
-      invitor_id:
-        type: string
-        format: uuid
-        description: The user that created the invitation
-        x-related-info:
-          model: user
-          label: username
       first_name:
         type: string
         maxLength: 100
@@ -832,14 +832,19 @@ definitions:
       email:
         type: string
         format: email
+      organisation_id:
+        type: integer
+        x-related-info:
+          model: organisationalunit
+          label: name
       expires_at:
         type: string
         format: 'date-time'
     required:
-      - invitor_id
       - first_name
       - last_name
       - email
+      - organisation_id
 
   invitation_update:
     type: object
@@ -853,6 +858,11 @@ definitions:
       email:
         type: string
         format: email
+      organisation_id:
+        type: integer
+        x-related-info:
+          model: organisationalunit
+          label: name
       expires_at:
         type: string
         format: 'date-time'


### PR DESCRIPTION
Note that I used "organisation_id" instead of "organisational_unit_id" in the invitation API calls. There is a separate ticket for me to change the existing things that refer to "organisationalunit".