### PR TITLE
Allow specifying API calls which are allowed to be made from the Management Portal

### DIFF
--- a/management_layer/api/views.py
+++ b/management_layer/api/views.py
@@ -7450,7 +7450,11 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
             "in": "query",
             "name": "domain_id",
             "required": false,
-            "type": "integer"
+            "type": "integer",
+            "x-related-info": {
+                "label": "name",
+                "rest_resource_name": "domains"
+            }
         },
         "optional_invitation_filter": {
             "description": "An optional query parameter to filter by invitation_id",
@@ -7494,7 +7498,11 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
             "in": "query",
             "name": "parent_id",
             "required": false,
-            "type": "integer"
+            "type": "integer",
+            "x-related-info": {
+                "label": "name",
+                "rest_resource_name": "domains"
+            }
         },
         "optional_portal_context_header": {
             "in": "header",
@@ -7507,14 +7515,22 @@ class __SWAGGER_SPEC__(View, CorsViewMixin):
             "in": "query",
             "name": "role_id",
             "required": false,
-            "type": "integer"
+            "type": "integer",
+            "x-related-info": {
+                "label": "label",
+                "rest_resource_name": "roles"
+            }
         },
         "optional_site_filter": {
             "description": "An optional query parameter to filter by site_id",
             "in": "query",
             "name": "site_id",
             "required": false,
-            "type": "integer"
+            "type": "integer",
+            "x-related-info": {
+                "label": "name",
+                "rest_resource_name": "sites"
+            }
         },
         "optional_user_filter": {
             "description": "An optional query parameter to filter by user_id",

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -311,7 +311,8 @@ class Implementation(AbstractStubClass):
 
     # domain_list -- Synchronisation point for meld
     @staticmethod
-    # GEINFRA-31: Any user should be able to list the domains. There is no sensitive information.
+    @require_permissions(all, [("urn:ge:access_control:domain", "read")],
+                         allow_for_management_portal=True)
     async def domain_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -368,7 +369,8 @@ class Implementation(AbstractStubClass):
 
     # domain_read -- Synchronisation point for meld
     @staticmethod
-    # GEINFRA-31: Any user should be able to read a domain. There is no sensitive information.
+    @require_permissions(all, [("urn:ge:access_control:domain", "read")],
+                         allow_for_management_portal=True)
     async def domain_read(request, domain_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1807,7 +1809,8 @@ class Implementation(AbstractStubClass):
 
     # site_list -- Synchronisation point for meld
     @staticmethod
-    # GEINFRA-31: Any user should be able to list sites. There is no sensitive information.
+    @require_permissions(all, [("urn:ge:access_control:site", "read")],
+                         allow_for_management_portal=True)
     async def site_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -1864,7 +1867,8 @@ class Implementation(AbstractStubClass):
 
     # site_read -- Synchronisation point for meld
     @staticmethod
-    # GEINFRA-31: Any user should be able to read a site. There is no sensitive information.
+    @require_permissions(all, [("urn:ge:access_control:site", "read")],
+                         allow_for_management_portal=True)
     async def site_read(request, site_id, **kwargs):
         """
         :param request: An HttpRequest

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -311,7 +311,7 @@ class Implementation(AbstractStubClass):
 
     # domain_list -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:domain", "read")])
+    # GEINFRA-31: Any user should be able to list the domains. There is no sensitive information.
     async def domain_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -368,7 +368,7 @@ class Implementation(AbstractStubClass):
 
     # domain_read -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:domain", "read")])
+    # GEINFRA-31: Any user should be able to read a domain. There is no sensitive information.
     async def domain_read(request, domain_id, **kwargs):
         """
         :param request: An HttpRequest
@@ -1807,7 +1807,7 @@ class Implementation(AbstractStubClass):
 
     # site_list -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:site", "read")])
+    # GEINFRA-31: Any user should be able to list sites. There is no sensitive information.
     async def site_list(request, **kwargs):
         """
         :param request: An HttpRequest
@@ -1864,7 +1864,7 @@ class Implementation(AbstractStubClass):
 
     # site_read -- Synchronisation point for meld
     @staticmethod
-    @require_permissions(all, [("urn:ge:access_control:site", "read")])
+    # GEINFRA-31: Any user should be able to read a site. There is no sensitive information.
     async def site_read(request, site_id, **kwargs):
         """
         :param request: An HttpRequest


### PR DESCRIPTION
# Background
When a user logs in to the Management Portal successfully, a context selector is presented first in order for the user to select a site or domain as context. The context selector needs to be able to get a list of domains and a list of sites regardless of whether the user has permission to do this.

# What was done
I added an `allow_for_management_portal` optional parameter to the `require_permissions` decorator. API calls that should be allowed for the Management Portal can now be indicated like this:
```python
    @require_permissions(all, [("urn:ge:access_control:site", "read")],
                         allow_for_management_portal=True)
    async def site_read(request, site_id, **kwargs):
```
