### PR TITLE
Added check to verify that a user is associated with an organisation

### DIFF
--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -1962,12 +1962,21 @@ class Implementation(AbstractStubClass):
         :returns: result or (result, headers) tuple
         """
         with client_exception_handler():
-            udr = await request.app["access_control_api"].userdomainrole_create(
+            user = await request.app["authentication_service_api"].user_read(user_id=body[
+                "user_id"])
+
+            if not user:
+                raise web.HTTPForbidden(text="The target user does not exist")
+
+            if user.organisation_id is None:
+                raise web.HTTPForbidden(text="The target user is not linked to an organisation")
+
+            user_domain_role = await request.app["access_control_api"].userdomainrole_create(
                 user_domain_role_create=body)
 
-        if udr:
+        if user_domain_role:
             transform = transformations.USER_DOMAIN_ROLE
-            result = transform.apply(udr.to_dict())
+            result = transform.apply(user_domain_role.to_dict())
             return result
 
         return None
@@ -2268,12 +2277,21 @@ class Implementation(AbstractStubClass):
         :returns: result or (result, headers) tuple
         """
         with client_exception_handler():
-            usr = await request.app["access_control_api"].usersiterole_create(
+            user = await request.app["authentication_service_api"].user_read(user_id=body[
+                "user_id"])
+
+            if not user:
+                raise web.HTTPForbidden(text="The target user does not exist")
+
+            if user.organisation_id is None:
+                raise web.HTTPForbidden(text="The target user is not linked to an organisation")
+
+            user_site_role = await request.app["access_control_api"].usersiterole_create(
                 user_site_role_create=body)
 
-        if usr:
+        if user_site_role:
             transform = transformations.USER_SITE_ROLE
-            result = transform.apply(usr.to_dict())
+            result = transform.apply(user_site_role.to_dict())
             return result
 
         return None

--- a/management_layer/integration.py
+++ b/management_layer/integration.py
@@ -798,7 +798,8 @@ class Implementation(AbstractStubClass):
     # get_sites_under_domain -- Synchronisation point for meld
     @staticmethod
     @require_permissions(all, [("urn:ge:access_control:domain", "read"),
-                               ("urn:ge:access_control:site", "read")])
+                               ("urn:ge:access_control:site", "read")],
+                         allow_for_management_portal=True)
     async def get_sites_under_domain(request, domain_id, **kwargs):
         """
         :param request: An HttpRequest

--- a/management_layer/tests/test_integration.py
+++ b/management_layer/tests/test_integration.py
@@ -27,8 +27,8 @@ from management_layer.api.urls import add_routes
 from management_layer.constants import TECH_ADMIN_ROLE_LABEL
 from management_layer.mappings import return_tech_admin_role_for_testing
 from management_layer.middleware import auth_middleware
-from management_layer.utils import return_users_with_roles, return_user_ids, return_site, TEST_SITE, \
-    return_client
+from management_layer.utils import return_users_with_roles, return_user_ids, return_sites, \
+    TEST_SITE, return_clients, return_user
 from user_data_store import UserDataApi
 
 LOGGER = logging.getLogger(__name__)
@@ -268,9 +268,11 @@ class ExampleTestCase(AioHTTPTestCase):
 @patch("authentication_service.api.authentication_api.AuthenticationApi.user_list",
        Mock(side_effect=return_user_ids))
 @patch("access_control.api.access_control_api.AccessControlApi.site_list",
-       Mock(side_effect=return_site))
+       Mock(side_effect=return_sites))
 @patch("authentication_service.api.authentication_api.AuthenticationApi.client_list",
-       Mock(side_effect=return_client))
+       Mock(side_effect=return_clients))
+@patch("authentication_service.api.authentication_api.AuthenticationApi.user_read",
+       Mock(side_effect=return_user))
 class IntegrationTest(AioHTTPTestCase):
     """
     Test functionality in integration.py

--- a/management_layer/utils.py
+++ b/management_layer/utils.py
@@ -95,7 +95,7 @@ def client_exception_handler():
             headers={"content-type": "application/json"},
             text=json.dumps({
                 "exception_type": "{}.{}".format(cre.__module__, cre.__class__.__name__),
-                "status": cre.code,
+                "status": cre.status,
                 "reason": cre.message,
                 "body": str(cre)
             }))
@@ -190,17 +190,39 @@ TEST_CLIENT = {
     "reuse_consent": True
 }
 
+TEST_USER = {
+    "id": "b001e842-4994-4c74-8db1-bb2caa42298a",
+    "username": "username",
+    "first_name": "first_name",
+    "last_name": "last_name",
+    "email": "email@example.com",
+    "is_active": True,
+    "date_joined": datetime.datetime(2018, 1, 1, 0, 0, 0),
+    "last_login": datetime.datetime(2018, 1, 1, 0, 0, 0),
+    "birth_date": datetime.datetime(2000, 1, 1, 0, 0, 0),
+    "country_code": "za",
+    "organisation_id": 1,
+    "created_at": datetime.datetime(2018, 1, 1, 0, 0, 0),
+    "updated_at": datetime.datetime(2018, 1, 1, 0, 0, 0)
+}
 
-async def return_site(*args, **kwargs):
+
+async def return_sites(*args, **kwargs):
     """
-    Some tests require a test site to be returned
+    Some tests require a test site list to be returned
     """
     return [Site(**TEST_SITE)]
 
 
-async def return_client(*args, **kwargs):
+async def return_clients(*args, **kwargs):
     """
-    Some tests require a test client to be returned
+    Some tests require a test client list to be returned
     """
     return [Client(**TEST_CLIENT)]
 
+
+async def return_user(*args, **kwargs):
+    """
+    Some tests require a test user to be returned
+    """
+    return User(**TEST_USER)


### PR DESCRIPTION
…before assigning a role on a site or domain.

Also sneaked in a change that will allow the Management Portal to call the `get_sites_under_domain` API call.