### PR TITLE
Stronger validation when creating/updating invitations

### DIFF
--- a/management_layer/exceptions.py
+++ b/management_layer/exceptions.py
@@ -11,8 +11,8 @@ class JSONException(web.HTTPException):
         # Use the json object given or create a message object using the string in message.
         text = json.dumps(json_data) if json_data else json.dumps({"message": message})
         # Super the web HTTPException, however force the content_type to application/json.
-        super().__init__(headers=headers, reason=reason, body=body,
-                         text=text, content_type="application/json")
+        super().__init__(headers=headers, reason=reason, body=body, text=text,
+                         content_type="application/json")
 
 
 class JSONBadRequest(JSONException):

--- a/management_layer/tests/test_integration.py
+++ b/management_layer/tests/test_integration.py
@@ -923,3 +923,28 @@ class IntegrationTest(AioHTTPTestCase):
         response = await self.client.post("/request_user_deletion", data=data)
         await self.assertStatus(response, 400)
 
+    @unittest_run_loop
+    async def test_cannot_create_or_update_invitation_for_existing_email(self):
+        # Invitation creation with existing email
+        invitation_create = {
+            "email": "jane@example.com",
+            "invitor_id": self.user_id,
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "organisation_id": 1
+        }
+        expected_response = {"message": "A user with the specified email address already exists."}
+        response = await self.client.post("/invitations", json=invitation_create)
+        await self.assertStatus(response, 400)
+        self.assertEqual(expected_response, await response.json())
+
+        # Invitation update with existing email
+        invitation_update = {
+            "email": "jane@example.com",
+        }
+        response = await self.client.put("/invitations/{}".format(uuid.uuid4().hex),
+                                         json=invitation_update
+                                        )
+        await self.assertStatus(response, 400)
+        self.assertEqual(expected_response, await response.json())
+

--- a/management_layer/tests/test_utils.py
+++ b/management_layer/tests/test_utils.py
@@ -1,9 +1,14 @@
 from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from aiohttp import web
 from aiohttp.client_exceptions import ClientResponseError, ClientConnectorError, \
     ClientConnectionError
+from aiohttp.test_utils import unittest_run_loop, make_mocked_request, AioHTTPTestCase
+from parameterized import parameterized
 
 from management_layer.exceptions import JSONBadGateway
-from management_layer.utils import client_exception_handler
+from management_layer.utils import client_exception_handler, return_users, user_with_email_exists
 import access_control.rest
 import authentication_service.rest
 import user_data_store.rest
@@ -52,3 +57,43 @@ class TestClientExceptionHandler(TestCase):
                     request_info="something",
                     history="something"
                 )
+
+
+@patch("authentication_service.api.authentication_api.AuthenticationApi.user_list",
+       Mock(side_effect=return_users))
+class TestUserWithEmailExists(AioHTTPTestCase):
+
+    async def get_application(self):
+        """
+        Set up the application used by the tests
+        :return:
+        """
+        app = web.Application(loop=self.loop)
+
+        authentication_service_configuration = authentication_service.configuration.Configuration()
+        authentication_service_configuration.host = f"http://localhost:8000/api/v1"
+        app["authentication_service_api"] = authentication_service.api.AuthenticationApi(
+            api_client=authentication_service.ApiClient(
+                configuration=authentication_service_configuration
+            )
+        )
+
+        async def on_shutdown(the_app):
+            await the_app["authentication_service_api"].api_client.rest_client.pool_manager.close()
+
+        app.on_shutdown.append(on_shutdown)
+        return app
+
+    @parameterized.expand([
+        # (email, expected_result)
+        ("jane@example.com", True),
+        ("JaNe@eXamplE.com", True),
+        ("jane123@example.com", False),
+        ("ajane@example.com", False)
+    ])
+    @unittest_run_loop
+    async def test_user_with_email_exists(self, email, expected_result):
+        mocked_request = make_mocked_request("GET", "/unused", app=self.app)
+        self.assertEqual(
+            expected_result,
+            await user_with_email_exists(mocked_request, email))

--- a/management_layer/utils.py
+++ b/management_layer/utils.py
@@ -18,7 +18,6 @@ from authentication_service import User, Client
 
 from management_layer import mappings, transformations
 from management_layer.exceptions import JSONBadGateway
-from management_layer.sentry import sentry
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +90,29 @@ def client_exception_handler():
                 "reason": cre.message,
                 "error": str(cre)
             })
+
+
+async def user_with_email_exists(request, email) -> bool:
+    """
+    A helper function to check if a user with the specified email
+    already exists.
+
+    The email filter can match partial email addresses that are similar,
+    but not equal, e.g. filtering on "email=foo@example.com" will match
+    also match "bar.foo@example.com". For this reason we have to
+    do a pass through all the results to see if we find an exact
+    case-insensitive match.
+
+    :param request: A request
+    :param email: The email to check
+    :return: True if a user with the specified email address exists, else False
+    """
+    with client_exception_handler():
+        users = await request.app[
+            "authentication_service_api"].user_list(email=email)
+
+    email_lower = email.lower()
+    return any(user.email.lower() == email_lower for user in users if user.email)
 
 
 async def transform_users_with_roles(request, response, **kwargs):
@@ -167,9 +189,9 @@ async def return_users_with_roles(*args, **kwargs):
 
 async def return_users(*args, **kwargs):
     """
-    Some test functions require to obtain a list of users with at least
-    an id and username that is what this will do.
-    :return: A list of uuid user_ids
+    Some test functions require a list of users with at least
+    an id and username. This function returns such a list.
+    :return: A list of users
     """
     data = [
         User(
@@ -179,9 +201,18 @@ async def return_users(*args, **kwargs):
             date_joined=datetime.date.today(),
             created_at=datetime.datetime.now(),
             updated_at=datetime.datetime.now()
+        ),
+        User(
+            id=uuid.uuid4(),
+            username="Jane",
+            is_active=True,
+            email="jane@example.com",
+            date_joined=datetime.date.today(),
+            created_at=datetime.datetime.now(),
+            updated_at=datetime.datetime.now()
         )
     ]
-    return data[kwargs["offset"]:]
+    return data[kwargs.get("offset", 0):]
 
 
 TEST_SITE = {


### PR DESCRIPTION
Return HTTP 400 when the email address specified in invitation create or update API call belongs to an existing user.